### PR TITLE
[YU-728] duckdb k8d deployment poc

### DIFF
--- a/charts/duckdb/Chart.yaml
+++ b/charts/duckdb/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: yuki-duckdb
+description: A Helm chart for Yuki duckdb deployment
+version: 0.0.1
+appVersion: "1.16.0"

--- a/charts/duckdb/templates/deployment.yaml
+++ b/charts/duckdb/templates/deployment.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.app.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.app.name }}
+  namespace: yuki-duckdb
+  labels:
+    app.kubernetes.io/name: {{ .Values.app.name }}
+    app.kubernetes.io/version: {{ .Release.Name }}-{{ .Release.Revision }}
+    app: {{ .Values.app.name }}
+    group: {{ .Values.app.group }}
+spec:
+  replicas: {{ .Values.app.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Values.app.name }}
+  template:
+    metadata:
+      namespace: yuki-duckdb
+      labels:
+        app: {{ .Values.app.name }}
+        group: {{ .Values.app.group }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.serviceAccountName | default "default" }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: duckdbrc-setup
+          image: busybox
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /secret/.duckdbrc /duckdb-home/.duckdbrc
+          volumeMounts:
+            - name: duckdb-home
+              mountPath: /duckdb-home
+            - name: duckdbrc
+              mountPath: /secret
+              readOnly: true
+      containers:
+        - name: {{ .Values.app.name }}
+          image: {{ .Values.app.container.image }}
+          restart:
+          tty: true
+          command:
+            - /bin/bash
+            - -c
+            - /app/duckdb
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.app.container.port }}
+              name: duckdb-http
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: duckdb-http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: duckdb-http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          volumeMounts:
+            - name: duckdb-home
+              mountPath: /home/duckdb
+      volumes:
+        - name: duckdb-home
+          emptyDir: { }
+        - name: duckdbrc
+          secret:
+            secretName: yuki-duckdb-secret
+{{- end }}

--- a/charts/duckdb/templates/iam-serviceaccount.yaml
+++ b/charts/duckdb/templates/iam-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.serviceAccountName }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.serviceAccountName }}
+  namespace: yuki-duckdb
+  annotations:
+    eks.amazonaws.com/role-arn: {{ required "AWS role arn must be set" .Values.serviceAccount.roleARN }}
+{{- end }}

--- a/charts/duckdb/templates/secret.yaml
+++ b/charts/duckdb/templates/secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.app.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.app.name }}-secret
+  namespace: yuki-duckdb
+  labels:
+    app.kubernetes.io/name: {{ .Values.app.name }}
+    app.kubernetes.io/version: {{ .Release.Name }}-{{ .Release.Revision }}
+    app: {{ .Values.app.name }}
+    group: {{ .Values.app.group }}
+data:
+  .duckdbrc: {{ list
+    ".mode trash"
+    "INSTALL httpserver FROM community;"
+    "INSTALL iceberg;"
+    "INSTALL httpfs;"
+    "LOAD httpserver;"
+    "CREATE OR REPLACE SECRET secret (TYPE s3, PROVIDER credential_chain);"
+    (printf "SELECT httpserve_start('0.0.0.0', %d, '%s');" (int64 .Values.app.container.port) (randAlphaNum 16))
+    | join "\n" | b64enc }}
+{{- end }}

--- a/charts/duckdb/templates/service.yaml
+++ b/charts/duckdb/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.name }}-svc
+  namespace: yuki-duckdb
+  labels: 
+    app.kubernetes.io/name: {{ .Values.app.name }}
+    app.kubernetes.io/version: {{ .Release.Name }}-{{ .Release.Revision }}
+    app: {{ .Values.app.name }}
+    group: {{ .Values.app.group }}
+spec:
+  type: {{ .Values.app.service.type | default "ClusterIP" }}
+  selector:             
+    app: {{ .Values.app.name }}
+  ports:
+    - name: duckdb
+      port: {{ .Values.app.service.port }}       
+      targetPort: duckdb-http
+      {{- if .Values.app.service.prometheus.enabled}}
+    - name: metric
+      port: 9090
+      targetPort: 9090
+      {{- end }}

--- a/charts/duckdb/values.yaml
+++ b/charts/duckdb/values.yaml
@@ -1,0 +1,31 @@
+app:
+  enabled: true
+  name: 'yuki-duckdb'
+  group: default-app-group
+  replicaCount: 1
+  container:
+    image: 406122784773.dkr.ecr.us-east-1.amazonaws.com/duckdb:1
+    port: 8080
+
+  service:
+    port: 80
+    prometheus:
+      enabled: false
+
+  secret:
+    name: yuki-duckdb-secret
+    key: duckdb-api-key
+
+serviceAccount:
+  roleARN: arn:aws:iam::406122784773:role/yuki-duckdb-role
+  serviceAccountName: 'yuki-duckdb-sa'
+
+resources:
+  requests:
+    memory: "1Gi"
+    cpu: "500m"
+  limits:
+    memory: "2Gi"
+
+affinity: {}
+tolerations: []


### PR DESCRIPTION
### Summary
initial POC deployment for duckdb on k8s, including
- minimal setup and configuration options
- configure `.duckdbrc` startup file as a secret (probably better to separate to configmap and inject secret to env vars then a script to combine them in an init container)
- service account usage tested with s3 tables

https://github.com/user-attachments/assets/3396c997-ec79-4608-86c0-9bd6708582ec

