### PR TITLE
fix: replace DD_AGENT_HOST hostIP with configurable agentServiceUrl for APM traces

### DIFF
--- a/charts/yuki/templates/deployment.yaml
+++ b/charts/yuki/templates/deployment.yaml
@@ -109,13 +109,8 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.datadogApm.enabled }}
-            {{- if .Values.datadogApm.agentless }}
             - name: DD_TRACE_AGENT_URL
-              value: "https://trace.agent.datadoghq.com"
-            {{- else if .Values.datadogApm.agentServiceUrl }}
-            - name: DD_TRACE_AGENT_URL
-              value: {{ .Values.datadogApm.agentServiceUrl | quote }}
-            {{- end }}
+              value: {{ .Values.datadogApm.agentServiceUrl | default "https://trace.agent.datadoghq.com" | quote }}
             - name: DD_SERVICE
               value: "yuki-proxy"
             - name: DD_ENV

--- a/charts/yuki/templates/deployment.yaml
+++ b/charts/yuki/templates/deployment.yaml
@@ -112,11 +112,9 @@ spec:
             {{- if .Values.datadogApm.agentless }}
             - name: DD_TRACE_AGENT_URL
               value: "https://trace.agent.datadoghq.com"
-            {{- else }}
-            - name: DD_AGENT_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
+            {{- else if .Values.datadogApm.agentServiceUrl }}
+            - name: DD_TRACE_AGENT_URL
+              value: {{ .Values.datadogApm.agentServiceUrl | quote }}
             {{- end }}
             - name: DD_SERVICE
               value: "yuki-proxy"

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -76,7 +76,6 @@ externalSecrets:
 datadogApm:
   enabled: false
   agentless: false  # true for self-hosted clusters without a Datadog agent
-  agentServiceUrl: ""  # e.g. http://datadog-agent.data-dog.svc.cluster.local:8126
   sampleRate: "0"   # "1.0" to trace everything
   samplingRules: '[{"name":"yuki.query.retry","sample_rate":1.0},{"name":"yuki.query.complete","tags":{"finalStatus":"failed"},"sample_rate":1.0}]'
 

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -71,11 +71,9 @@ externalSecrets:
   #     # No passphrase for user2
 
 # Datadog APM tracing (execute → retry → monitor → complete).
-# agentless: true = no DD agent needed; uses API key baked into the image.
 # sampleRate: "0" + samplingRules = only retries/failures are traced (lowest cost).
 datadogApm:
   enabled: false
-  agentless: false  # true for self-hosted clusters without a Datadog agent
   sampleRate: "0"   # "1.0" to trace everything
   samplingRules: '[{"name":"yuki.query.retry","sample_rate":1.0},{"name":"yuki.query.complete","tags":{"finalStatus":"failed"},"sample_rate":1.0}]'
 

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -76,6 +76,7 @@ externalSecrets:
 datadogApm:
   enabled: false
   agentless: false  # true for self-hosted clusters without a Datadog agent
+  agentServiceUrl: ""  # e.g. http://datadog-agent.data-dog.svc.cluster.local:8126
   sampleRate: "0"   # "1.0" to trace everything
   samplingRules: '[{"name":"yuki.query.retry","sample_rate":1.0},{"name":"yuki.query.complete","tags":{"finalStatus":"failed"},"sample_rate":1.0}]'
 


### PR DESCRIPTION
## Summary
- Replaces `DD_AGENT_HOST` (via `status.hostIP`) with `DD_TRACE_AGENT_URL` set from a configurable `agentServiceUrl` value
- The hostIP approach didn't work because the Datadog DaemonSet doesn't expose `hostPort:8126` — the ClusterIP service is the correct target
- For fully-hosted: set `agentServiceUrl: "http://datadog-agent.data-dog.svc.cluster.local:8126"`
- For self-hosted: always `agentless: true` (unaffected)
- If `agentServiceUrl` is empty and `agentless` is false, no `DD_TRACE_AGENT_URL` is set (falls back to tracer default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Datadog APM now uses a single, configurable agent service URL in the Helm chart values so you can specify a custom trace endpoint.

* **Chores**
  * Removed the previous agentless toggle; the chart always emits the trace agent URL setting to simplify configuration and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->