### PR TITLE
[YU-1454] feat: expose proxy identity and version as container env vars

### DIFF
--- a/charts/yuki/templates/deployment.yaml
+++ b/charts/yuki/templates/deployment.yaml
@@ -64,8 +64,6 @@ spec:
           env:
             - name: PROXY_VERSION
               value: "{{ tpl .Values.app.container.image . | splitList ":" | last }}"
-            - name: PROXY_ID
-              value: "{{ .Release.Name }}"
             - name: HELM_CHART_VERSION
               value: "{{ .Chart.Version }}"
             - name: IMAGE_VERSION

--- a/charts/yuki/templates/deployment.yaml
+++ b/charts/yuki/templates/deployment.yaml
@@ -64,6 +64,12 @@ spec:
           env:
             - name: PROXY_VERSION
               value: "{{ tpl .Values.app.container.image . | splitList ":" | last }}"
+            - name: PROXY_ID
+              value: "{{ .Release.Name }}"
+            - name: HELM_CHART_VERSION
+              value: "{{ .Chart.Version }}"
+            - name: IMAGE_VERSION
+              value: "{{ tpl .Values.app.container.image . | splitList ":" | last }}"
             - name: REDIS_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- Adds `PROXY_ID` (`{{ .Release.Name }}`) — stable unique ID per Helm installation, useful for correlating logs/metrics across upgrades
- Adds `HELM_CHART_VERSION` (`{{ .Chart.Version }}`) — chart version baked into the running container for telemetry/debugging
- Adds `IMAGE_VERSION` (`{{ tpl .Values.app.container.image . | splitList ":" | last }}`) — image tag extracted the same way as the existing `PROXY_VERSION` env var

All three vars are inserted immediately after the existing `PROXY_VERSION` entry, following the repo's existing env var style.

## Test plan

- [ ] `helm template` renders correctly with expected values for all three new env vars
- [ ] Deployed pod shows correct values for `PROXY_ID`, `HELM_CHART_VERSION`, and `IMAGE_VERSION` via `kubectl exec ... -- env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Exposed additional deployment metadata to the running container as environment variables, adding chart version and image version for improved operational visibility and easier debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->