### PR TITLE
feat: add PROXY_TYPE env var to deployment template

### DIFF
--- a/charts/yuki/templates/deployment.yaml
+++ b/charts/yuki/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
           ports:
             - containerPort: {{ .Values.app.container.port }}
           env:
+            - name: PROXY_TYPE
+              value: "{{ ternary "fully_hosted" "self_hosted" .Values.ingress.enabled }}"
             - name: PROXY_VERSION
               value: "{{ tpl .Values.app.container.image . | splitList ":" | last }}"
             - name: HELM_CHART_VERSION

--- a/charts/yuki/templates/deployment.yaml
+++ b/charts/yuki/templates/deployment.yaml
@@ -63,7 +63,9 @@ spec:
             - containerPort: {{ .Values.app.container.port }}
           env:
             - name: PROXY_TYPE
-              value: "{{ ternary "fully_hosted" "self_hosted" .Values.ingress.enabled }}"
+              value: "{{ .Values.proxyType }}"
+            - name: PROXY_PLATFORM
+              value: "{{ .Values.proxyPlatform }}"
             - name: PROXY_VERSION
               value: "{{ tpl .Values.app.container.image . | splitList ":" | last }}"
             - name: HELM_CHART_VERSION

--- a/charts/yuki/templates/deployment.yaml
+++ b/charts/yuki/templates/deployment.yaml
@@ -62,10 +62,8 @@ spec:
           ports:
             - containerPort: {{ .Values.app.container.port }}
           env:
-            - name: PROXY_TYPE
-              value: "{{ .Values.proxyType }}"
-            - name: PROXY_PLATFORM
-              value: "{{ .Values.proxyPlatform }}"
+            - name: PROXY_DEPLOYMENT_TYPE
+              value: "{{ .Values.proxyDeploymentType }}"
             - name: PROXY_VERSION
               value: "{{ tpl .Values.app.container.image . | splitList ":" | last }}"
             - name: HELM_CHART_VERSION

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -84,8 +84,7 @@ hpa:
   targetCPUUtilizationPercentage: 90
   targetMemoryUtilizationPercentage: 70
 
-proxyType: self_hosted
-proxyPlatform: ""
+proxyDeploymentType: self_hosted
 
 ingress:
   enabled: false

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -84,6 +84,9 @@ hpa:
   targetCPUUtilizationPercentage: 90
   targetMemoryUtilizationPercentage: 70
 
+proxyType: self_hosted
+proxyPlatform: ""
+
 ingress:
   enabled: false
 


### PR DESCRIPTION
## Summary
- Adds `PROXY_TYPE` env var to the Deployment template
- Value is `fully_hosted` when `ingress.enabled` is true, `self_hosted` otherwise
- Uses Helm's `ternary` function to derive the value from the existing `ingress.enabled` flag

## Test plan
- [ ] Deploy with `ingress.enabled: true` and verify `PROXY_TYPE=fully_hosted` in the pod env
- [ ] Deploy with `ingress.enabled: false` and verify `PROXY_TYPE=self_hosted` in the pod env
- [ ] Run `helm template` and confirm the rendered value matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a chart value to configure proxy deployment mode (default: self_hosted).

* **Chores**
  * Deployment now exposes the selected proxy deployment mode to the running service via an environment variable so runtime behavior reflects chart settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->