### PR TITLE
feat(mcp): add gated yuki-mcp deployment templates (YU-2023)

### DIFF
--- a/charts/yuki/templates/_helpers.tpl
+++ b/charts/yuki/templates/_helpers.tpl
@@ -34,3 +34,19 @@
 INGESTION_KEY
 {{- end -}}
 {{- end -}}
+
+{{/* Short env token for secret paths: staging→stg, production→prod, development→dev. */}}
+{{- define "mcp.envShort" -}}
+{{- $env := .Values.app.container.env.ENVIRONMENT | default "production" -}}
+{{- if   eq $env "staging"     -}}stg
+{{- else if eq $env "production"  -}}prod
+{{- else if eq $env "development" -}}dev
+{{- else -}}{{ fail (printf "mcp.envShort: unknown ENVIRONMENT %q (expected staging|production|development)" $env) }}
+{{- end -}}
+{{- end -}}
+
+{{/* AWS Secrets Manager path for the MCP OAuth client creds: {envShort}/yuki-mcp/{account-id}. */}}
+{{- define "mcp.secretName" -}}
+{{- $acct := required "app.container.env.ACCOUNT_GUID is required when mcp.enabled" .Values.app.container.env.ACCOUNT_GUID -}}
+{{- printf "%s/yuki-mcp/%s" (include "mcp.envShort" .) $acct -}}
+{{- end -}}

--- a/charts/yuki/templates/_helpers.tpl
+++ b/charts/yuki/templates/_helpers.tpl
@@ -37,7 +37,7 @@ INGESTION_KEY
 
 {{/* Short env token for secret paths: staging→stg, production→prod, development→dev. */}}
 {{- define "mcp.envShort" -}}
-{{- $env := .Values.app.container.env.ENVIRONMENT | default "production" -}}
+{{- $env := required "app.container.env.ENVIRONMENT is required when mcp.enabled" .Values.app.container.env.ENVIRONMENT -}}
 {{- if   eq $env "staging"     -}}stg
 {{- else if eq $env "production"  -}}prod
 {{- else if eq $env "development" -}}dev

--- a/charts/yuki/templates/deployment-mcp.yaml
+++ b/charts/yuki/templates/deployment-mcp.yaml
@@ -53,7 +53,7 @@ spec:
             - name: YUKI_MCP_BASE_URL
               value: {{ .Values.mcp.baseUrl | quote }}
             - name: YUKI_PLATFORM_URL
-              value: {{ .Values.mcp.platformUrl | default "https://app.yukistaging.com" | quote }}
+              value: {{ .Values.mcp.platformUrl | default "https://app.yukicomputing.com" | quote }}
             - name: YUKI_ALLOWED_REDIRECT_URIS
               value: {{ .Values.mcp.allowedRedirectUris | default "" | quote }}
             - name: CORS_ALLOWED_ORIGINS

--- a/charts/yuki/templates/deployment-mcp.yaml
+++ b/charts/yuki/templates/deployment-mcp.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yuki-mcp
+  labels:
+    app.kubernetes.io/name: yuki-mcp
+    app.kubernetes.io/version: {{ .Release.Name }}-{{ .Release.Revision }}
+    app: yuki-mcp
+    group: {{ .Values.app.group }}
+spec:
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  {{- if not .Values.mcp.hpa.enabled }}
+  replicas: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      app: yuki-mcp
+  template:
+    metadata:
+      labels:
+        app: yuki-mcp
+        group: {{ .Values.app.group }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.serviceAccountName | default "default" }}
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: yuki-mcp
+          image: {{ tpl .Values.mcp.container.image . }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            - name: ENVIRONMENT
+              value: {{ .Values.app.container.env.ENVIRONMENT | default "production" | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.mcp.logLevel | default "INFO" | quote }}
+            - name: YUKI_MCP_BASE_URL
+              value: {{ .Values.mcp.baseUrl | quote }}
+            - name: YUKI_PLATFORM_URL
+              value: {{ .Values.mcp.platformUrl | default "https://app.yukistaging.com" | quote }}
+            - name: YUKI_ALLOWED_REDIRECT_URIS
+              value: {{ .Values.mcp.allowedRedirectUris | default "" | quote }}
+            - name: CORS_ALLOWED_ORIGINS
+              value: {{ .Values.mcp.corsAllowedOrigins | default "" | quote }}
+            - name: SYSTEM_API_URL
+              value: "http://system-api.yuki-compute:5194"
+            - name: SYSTEM_API_COMPANY_ID
+              value: {{ .Values.app.container.env.COMPANY_GUID | quote }}
+            - name: SYSTEM_API_ACCOUNT_ID
+              value: {{ .Values.app.container.env.ACCOUNT_GUID | quote }}
+            - name: SNOWFLAKE_ACCOUNT
+              value: {{ .Values.mcp.snowflakeAccount | quote }}
+            - name: SNOWFLAKE_HOST
+              value: "yuki-proxy"
+            - name: SNOWFLAKE_PORT
+              value: "5162"
+            - name: SNOWFLAKE_PROTOCOL
+              value: "http"
+            - name: AWS_REGION
+              value: {{ .Values.app.container.env.AWS_REGION | default "eu-north-1" | quote }}
+            - name: YUKI_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: yuki-mcp-secrets
+                  key: yuki-client-id
+            - name: YUKI_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: yuki-mcp-secrets
+                  key: yuki-client-secret
+          {{- with .Values.mcp.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/yuki/templates/deployment-mcp.yaml
+++ b/charts/yuki/templates/deployment-mcp.yaml
@@ -72,6 +72,8 @@ spec:
               value: "5162"
             - name: SNOWFLAKE_PROTOCOL
               value: "http"
+            - name: HOME
+              value: /tmp
             - name: AWS_REGION
               value: {{ .Values.app.container.env.AWS_REGION | default "eu-north-1" | quote }}
             - name: YUKI_CLIENT_ID

--- a/charts/yuki/templates/externalsecret-mcp.yaml
+++ b/charts/yuki/templates/externalsecret-mcp.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: yuki-mcp-secrets
+  labels:
+    app.kubernetes.io/name: yuki-mcp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: yuki-mcp-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: yuki-client-id
+      remoteRef:
+        key: yuki-mcp/secrets
+        property: yuki-client-id
+    - secretKey: yuki-client-secret
+      remoteRef:
+        key: yuki-mcp/secrets
+        property: yuki-client-secret
+{{- end }}

--- a/charts/yuki/templates/externalsecret-mcp.yaml
+++ b/charts/yuki/templates/externalsecret-mcp.yaml
@@ -16,10 +16,10 @@ spec:
   data:
     - secretKey: yuki-client-id
       remoteRef:
-        key: yuki-mcp/secrets
+        key: {{ include "mcp.secretName" . | quote }}
         property: yuki-client-id
     - secretKey: yuki-client-secret
       remoteRef:
-        key: yuki-mcp/secrets
+        key: {{ include "mcp.secretName" . | quote }}
         property: yuki-client-secret
 {{- end }}

--- a/charts/yuki/templates/hpa-mcp.yaml
+++ b/charts/yuki/templates/hpa-mcp.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.mcp.enabled .Values.mcp.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: yuki-mcp
+  labels:
+    app: yuki-mcp
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: yuki-mcp
+  minReplicas: {{ .Values.mcp.hpa.minReplicas }}
+  maxReplicas: {{ .Values.mcp.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.mcp.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.mcp.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/charts/yuki/templates/ingress.yaml
+++ b/charts/yuki/templates/ingress.yaml
@@ -15,8 +15,9 @@ spec:
     - http:
         paths:
           {{- if .Values.mcp.enabled }}
-          # yuki-mcp: OAuth flow + MCP endpoint live under /mcp, but RFC 8414/9728
-          # discovery must resolve at the origin root, so route both prefixes.
+          # yuki-mcp mounts the MCP endpoint at /mcp, the OAuth flow at /oauth +
+          # /register, and RFC 8414/9728 discovery at the origin root — route all
+          # of them, or the unlisted ones fall through to the / proxy backend.
           # ponytail: /.well-known is greedy — fine here (ALB+ACM, no ACME challenge);
           # narrow to the three oauth-*/openid-configuration paths if the app ever needs its own.
           - path: /mcp
@@ -27,6 +28,20 @@ spec:
                 port:
                   number: 8000
           - path: /.well-known
+            pathType: Prefix
+            backend:
+              service:
+                name: yuki-mcp
+                port:
+                  number: 8000
+          - path: /oauth
+            pathType: Prefix
+            backend:
+              service:
+                name: yuki-mcp
+                port:
+                  number: 8000
+          - path: /register
             pathType: Prefix
             backend:
               service:

--- a/charts/yuki/templates/ingress.yaml
+++ b/charts/yuki/templates/ingress.yaml
@@ -14,6 +14,37 @@ spec:
   rules:
     - http:
         paths:
+          {{- if .Values.mcp.enabled }}
+          # MCP paths must precede / so the ALB matches them first (prefix specificity).
+          - path: /mcp
+            pathType: Prefix
+            backend:
+              service:
+                name: yuki-mcp
+                port:
+                  number: 8000
+          - path: /.well-known
+            pathType: Prefix
+            backend:
+              service:
+                name: yuki-mcp
+                port:
+                  number: 8000
+          - path: /oauth
+            pathType: Prefix
+            backend:
+              service:
+                name: yuki-mcp
+                port:
+                  number: 8000
+          - path: /register
+            pathType: Prefix
+            backend:
+              service:
+                name: yuki-mcp
+                port:
+                  number: 8000
+          {{- end }}
           - path: /
             pathType: Prefix
             backend:

--- a/charts/yuki/templates/ingress.yaml
+++ b/charts/yuki/templates/ingress.yaml
@@ -15,7 +15,10 @@ spec:
     - http:
         paths:
           {{- if .Values.mcp.enabled }}
-          # MCP paths must precede / so the ALB matches them first (prefix specificity).
+          # yuki-mcp: OAuth flow + MCP endpoint live under /mcp, but RFC 8414/9728
+          # discovery must resolve at the origin root, so route both prefixes.
+          # ponytail: /.well-known is greedy — fine here (ALB+ACM, no ACME challenge);
+          # narrow to the three oauth-*/openid-configuration paths if the app ever needs its own.
           - path: /mcp
             pathType: Prefix
             backend:
@@ -24,20 +27,6 @@ spec:
                 port:
                   number: 8000
           - path: /.well-known
-            pathType: Prefix
-            backend:
-              service:
-                name: yuki-mcp
-                port:
-                  number: 8000
-          - path: /oauth
-            pathType: Prefix
-            backend:
-              service:
-                name: yuki-mcp
-                port:
-                  number: 8000
-          - path: /register
             pathType: Prefix
             backend:
               service:

--- a/charts/yuki/templates/service-mcp.yaml
+++ b/charts/yuki/templates/service-mcp.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: yuki-mcp
+  labels:
+    app.kubernetes.io/name: yuki-mcp
+    app.kubernetes.io/version: {{ .Release.Name }}-{{ .Release.Revision }}
+    app: yuki-mcp
+    group: {{ .Values.app.group }}
+spec:
+  type: ClusterIP
+  selector:
+    app: yuki-mcp
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -210,7 +210,7 @@ mcp:
   container:
     image: ""          # set per-environment: <ecrArn>/yuki-mcp:<tag>
   baseUrl: ""          # public HTTPS URL, e.g. https://<namespace>.yukistaging.com
-  platformUrl: "https://app.yukistaging.com"
+  platformUrl: "https://app.yukicomputing.com"  # prod default; override per-environment
   allowedRedirectUris: ""  # comma-separated; blank = allow any (dev only)
   corsAllowedOrigins: ""   # comma-separated; blank = wildcard (set explicitly in staging/prod)
   snowflakeAccount: ""     # Snowflake account id, e.g. jsjvnsg-staging

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -203,3 +203,27 @@ groundcover:
       limits:
         cpu: 50m
         memory: 64Mi
+
+# MCP server — gated, default off; existing deployments are unchanged.
+mcp:
+  enabled: false
+  container:
+    image: ""          # set per-environment: <ecrArn>/yuki-mcp:<tag>
+  baseUrl: ""          # public HTTPS URL, e.g. https://<namespace>.yukistaging.com
+  platformUrl: "https://app.yukistaging.com"
+  allowedRedirectUris: ""  # comma-separated; blank = allow any (dev only)
+  corsAllowedOrigins: ""   # comma-separated; blank = wildcard (set explicitly in staging/prod)
+  snowflakeAccount: ""     # Snowflake account id, e.g. jsjvnsg-staging
+  logLevel: "INFO"
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 75
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      memory: "512Mi"


### PR DESCRIPTION
## Summary

- Adds `deployment-mcp.yaml`, `service-mcp.yaml`, `hpa-mcp.yaml`, `externalsecret-mcp.yaml` templates — all gated on `mcp.enabled: false` (default off, existing tenants unchanged)
- Extends `ingress.yaml` to prepend `/mcp`, `/.well-known`, `/oauth`, `/register` paths to the existing ALB when `mcp.enabled=true` (higher specificity → matched before `/`)
- Adds `mcp:` values block to `values.yaml` with sensible staging defaults
- MCP pod reuses `yuki-proxy-sa` (IRSA) for Secrets Manager access — no new IAM
- `ExternalSecret` references `aws-secrets-manager` ClusterSecretStore, syncs `yuki-mcp/secrets` → `yuki-client-id` / `yuki-client-secret`
- Routes Snowflake queries in-cluster: `SNOWFLAKE_HOST=yuki-proxy`, `SNOWFLAKE_PORT=5162`, `SNOWFLAKE_PROTOCOL=http`

## Test plan

- [ ] `helm template charts/yuki -f <staging+account values> --set mcp.enabled=true` renders deployment-mcp, service-mcp, externalsecret-mcp and ingress has /mcp before /
- [ ] With `mcp.enabled=false` (default): none of the new resources appear, existing templates unchanged
- [ ] After merge: bump `proxyChartVersion` in terraform-infra staging base values to the new released version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional MCP support to the Helm chart, including a dedicated Deployment and ClusterIP Service.
  * Extended Ingress with MCP routes (`/mcp` and `/.well-known`) forwarding to the MCP service.
  * Added an MCP configuration section for URLs/OAuth/CORS, Snowflake settings, logging, and resource tuning.
  * Added ExternalSecret-based provisioning of MCP OAuth client credentials from AWS Secrets Manager.
  * Added optional HPA for MCP when enabled.
* **Security & Reliability**
  * Hardened the MCP container and added liveness/readiness probes.
* **Bug Fixes**
  * Ensured MCP routes take precedence over the default catch-all route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->