### PR TITLE
YU-2102 - Groundcover: nodeSelector co-location, Helm 4 null-safety, k8s-watcher req fix

### DIFF
--- a/charts/yuki/examples/values-as-subchart.yaml
+++ b/charts/yuki/examples/values-as-subchart.yaml
@@ -1,0 +1,41 @@
+# Example: consuming this chart as a SUBCHART from your own umbrella chart.
+#
+# In your umbrella Chart.yaml, the dependency key is the chart NAME ("proxy")
+# unless you set an alias:
+#
+#   dependencies:
+#     - name: proxy
+#       version: 0.0.119
+#       repository: https://<yuki-helm-repo>
+#       # alias: yuki-proxy   # only if you want the values key to be "yuki-proxy"
+#
+# Then this file is your umbrella values.yaml. Two rules that trip people up:
+#   1. global.groundcover_token goes at the UMBRELLA TOP LEVEL (below) — NOT under
+#      proxy:. It's a Helm global; that's how it reaches the groundcover sub-subchart.
+#   2. Everything else nests under the dependency key ("proxy:" here).
+
+# Helm global — top level. Never commit a real key; pass via --set or a private file.
+global:
+  groundcover_token: ""
+
+proxy:
+  app:
+    container:
+      image: <registry>/yuki-proxy:<tag>
+      env:
+        PROXY_HOST: https://<account>.snowflakecomputing.com
+        REDIS_HOST: <redis-host>:6379
+
+  # Pin the proxy AND the sensor to the same node(s). nodeSelector must be set in
+  # BOTH places below — groundcover's sensor reads no shared/global nodeSelector,
+  # so a single value can't reach both. First label the nodes:
+  #   kubectl label node <node> yuki.io/workload=proxy
+  nodeSelector:
+    yuki.io/workload: proxy            # proxy pods
+
+  groundcover:
+    enabled: true
+    clusterId: <customer>
+    agent:
+      nodeSelector:
+        yuki.io/workload: proxy        # sensor pods — keep identical to the above

--- a/charts/yuki/examples/values-groundcover-sensor.yaml
+++ b/charts/yuki/examples/values-groundcover-sensor.yaml
@@ -8,9 +8,14 @@
 #     --set app.container.env.PROXY_HOST=https://<account>.snowflakecomputing.com \
 #     --set app.container.env.REDIS_HOST=<redis-host>:6379
 #
-# The sensor auto-co-locates with the proxy (pod affinity in the chart defaults) —
-# no node labels needed, and Groundcover sees only the proxy's nodes.
+# By default the sensor runs on all non-Fargate nodes. To pin it to just the
+# proxy's nodes, label them and set the SAME nodeSelector on the proxy and the
+# sensor (see the nodeSelector keys below).
+nodeSelector: {}            # proxy pods, e.g. { yuki.io/workload: proxy }
 groundcover:
   enabled: true
   clusterId: yuki-proxy-demo
   env: stg
+  agent:
+    nodeSelector: {}        # sensor pods — set to the SAME labels as nodeSelector above
+                            # (must be set in both places; groundcover reads no shared global)

--- a/charts/yuki/templates/NOTES.txt
+++ b/charts/yuki/templates/NOTES.txt
@@ -16,7 +16,7 @@ Groundcover eBPF sensor (BYOC):
   - Ships to:           {{ .Values.groundcover.global.ingress.site }}
 {{- end }}
 
-{{- if not (or .Values.global.groundcover_token .Values.observability.groundcover.existingSecret.name) }}
+{{- if not (or (.Values.global).groundcover_token .Values.observability.groundcover.existingSecret.name) }}
 
   ⚠  No Groundcover ingestion key configured. Telemetry will NOT be delivered.
      Set one of:

--- a/charts/yuki/templates/deployment.yaml
+++ b/charts/yuki/templates/deployment.yaml
@@ -98,8 +98,12 @@ spec:
               value: "service.version=$(PROXY_VERSION),deployment.environment={{ .Values.app.container.env.ASPNETCORE_ENVIRONMENT | lower }}"
             {{- end }}
             {{- range $key, $value := .Values.app.container.env }}
+            {{- /* Skip null placeholders (e.g. PROXY_HOST:) — Helm 3 would
+                   render them as empty env vars, Helm 4 drops them. */}}
+            {{- if not (kindIs "invalid" $value) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
             {{- range $key, $value := .Values.app.container.envFromSecrets }}
             - name: {{ $key }}

--- a/charts/yuki/templates/observability/groundcover-secret.yaml
+++ b/charts/yuki/templates/observability/groundcover-secret.yaml
@@ -1,7 +1,7 @@
 {{- include "proxy.observability.validate" . -}}
 {{- /* Ingestion-key Secret for the OTLP collector. Only the otlp backend needs
        it; the sensor subchart provisions its own from global.groundcover_token. */ -}}
-{{- if and (eq .Values.observability.backend "otlp") .Values.global.groundcover_token (not .Values.observability.groundcover.existingSecret.name) }}
+{{- if and (eq .Values.observability.backend "otlp") (.Values.global).groundcover_token (not .Values.observability.groundcover.existingSecret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,5 +12,5 @@ metadata:
     app.kubernetes.io/component: observability
 type: Opaque
 stringData:
-  INGESTION_KEY: {{ .Values.global.groundcover_token | quote }}
+  INGESTION_KEY: {{ (.Values.global).groundcover_token | quote }}
 {{- end }}

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -124,10 +124,9 @@ external-secrets:
   serviceAccount:
     create: true
 
-# Groundcover ingestion key — set once here (or via --set / private file;
-# never commit). Shared with the subchart (sensor auth) and read by the parent
-# (OTLP collector Secret). Name must stay `groundcover_token` — the subchart
-# reads that key.
+# Groundcover ingestion key — set once (via --set or a private file; never commit).
+# Shared by the sensor subchart and the OTLP collector. As a subchart, set it at the
+# umbrella top level (global.*), not under the proxy alias.
 global:
   groundcover_token: ""
 
@@ -180,26 +179,20 @@ groundcover:
     # groundcoverPredefinedTokenSecret:
     #   secretName: groundcover-ingestion-key
     #   secretKey: INGESTION_KEY
-  # Sensor auto-co-locates with the proxy: each pod schedules only onto a node
-  # running a yuki-proxy pod (Pending elsewhere). No node labels needed.
-  # Update the selector if you override app.name; set agent.affinity: {} for all nodes.
+  # Sensor runs on all non-Fargate nodes by default. To pin it to the proxy's nodes,
+  # label them and set the same nodeSelector here and on the proxy top-level
+  # `nodeSelector`. Avoid `affinity: null` (Helm 4 strips the Fargate guard).
   agent:
-    affinity:
-      podAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app: yuki-proxy
-            topologyKey: kubernetes.io/hostname
+    nodeSelector: {}
   vector:
     enabled: false        # not needed in BYOC; sensor ships directly
   # k8s-watcher: REQUIRED for Groundcover to attribute traffic to workloads
-  # (no enable toggle in the subchart); resources trimmed to fit small nodes.
+  # (no enable toggle in the subchart). 256Mi — 64Mi gets OOM-killed under load.
   k8sWatcher:
     resources:
       requests:
         cpu: 10m
-        memory: 32Mi
+        memory: 128Mi
       limits:
         cpu: 50m
-        memory: 64Mi
+        memory: 256Mi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm example values for consuming the chart as a subchart.
  * Added clearer example configuration for pinning the proxy and sensor pods to the same Kubernetes nodes via matching `nodeSelector` labels.

* **Bug Fixes**
  * Fixed Helm rendering to skip invalid/placeholder environment variable values.
  * Improved Groundcover token secret and setup warning logic to use consistent global configuration.

* **Documentation**
  * Updated chart values guidance for setting ingestion credentials and node scheduling; adjusted default sensor watcher resource settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->