### PR TITLE
Add passthrough workload for Snowflake/BigQuery bypass (disabled by default)

### DIFF
--- a/charts/yuki/templates/_helpers.tpl
+++ b/charts/yuki/templates/_helpers.tpl
@@ -40,7 +40,7 @@ INGESTION_KEY
 {{- or .Values.passthrough.snowflakeHost .Values.app.container.env.PROXY_HOST "" -}}
 {{- end -}}
 
-{{/* Host header for the Snowflake passthrough — Snowflake sees Yuki's hosted domain, not its own. */}}
+{{/* Snowflake's real host — the client's request instead targets Yuki's hosted domain, so this is what gets rewritten in. */}}
 {{- define "proxy.passthrough.snowflakeHostHeader" -}}
 {{- (include "proxy.passthrough.snowflakeUrl" . | urlParse).host -}}
 {{- end -}}

--- a/charts/yuki/templates/_helpers.tpl
+++ b/charts/yuki/templates/_helpers.tpl
@@ -40,11 +40,6 @@ INGESTION_KEY
 {{- or .Values.passthrough.snowflakeHost .Values.app.container.env.PROXY_HOST "" -}}
 {{- end -}}
 
-{{/* Snowflake's real host — the client's request instead targets Yuki's hosted domain, so this is what gets rewritten in. */}}
-{{- define "proxy.passthrough.snowflakeHostHeader" -}}
-{{- (include "proxy.passthrough.snowflakeUrl" . | urlParse).host -}}
-{{- end -}}
-
 {{/* BigQuery URL the passthrough forwards to — same fixed Google endpoint for every account. */}}
 {{- define "proxy.passthrough.bigqueryUrl" -}}
 {{- or .Values.passthrough.bigqueryHost .Values.app.container.env.BIGQUERY_HOST "" -}}
@@ -55,8 +50,9 @@ INGESTION_KEY
 {{- include "proxy.passthrough.bigqueryUrl" . | default (include "proxy.passthrough.snowflakeUrl" .) -}}
 {{- end -}}
 
-{{- define "proxy.passthrough.isBigQuery" -}}
-{{- if include "proxy.passthrough.bigqueryUrl" . -}}true{{- end -}}
+{{/* Real upstream host — the client's request instead targets Yuki's hosted domain, so this is what gets rewritten in. */}}
+{{- define "proxy.passthrough.upstreamHostHeader" -}}
+{{- (include "proxy.passthrough.upstreamUrl" . | urlParse).host -}}
 {{- end -}}
 
 {{/* Env token for secret paths: staging→stg, production→prod, development→dev. */}}

--- a/charts/yuki/templates/_helpers.tpl
+++ b/charts/yuki/templates/_helpers.tpl
@@ -35,14 +35,28 @@ INGESTION_KEY
 {{- end -}}
 {{- end -}}
 
-{{/* Snowflake URL the passthrough forwards to. */}}
+{{/* Snowflake URL the passthrough forwards to; trailing "" avoids "<no value>" when unset. */}}
 {{- define "proxy.passthrough.snowflakeUrl" -}}
-{{- .Values.passthrough.snowflakeHost | default .Values.app.container.env.PROXY_HOST -}}
+{{- or .Values.passthrough.snowflakeHost .Values.app.container.env.PROXY_HOST "" -}}
 {{- end -}}
 
-{{/* Host header for the passthrough. */}}
+{{/* Host header for the Snowflake passthrough — Snowflake sees Yuki's hosted domain, not its own. */}}
 {{- define "proxy.passthrough.snowflakeHostHeader" -}}
 {{- (include "proxy.passthrough.snowflakeUrl" . | urlParse).host -}}
+{{- end -}}
+
+{{/* BigQuery URL the passthrough forwards to — same fixed Google endpoint for every account. */}}
+{{- define "proxy.passthrough.bigqueryUrl" -}}
+{{- or .Values.passthrough.bigqueryHost .Values.app.container.env.BIGQUERY_HOST "" -}}
+{{- end -}}
+
+{{/* Whichever backend is configured — BigQuery takes precedence, matching ClientProxy's own route order. */}}
+{{- define "proxy.passthrough.upstreamUrl" -}}
+{{- include "proxy.passthrough.bigqueryUrl" . | default (include "proxy.passthrough.snowflakeUrl" .) -}}
+{{- end -}}
+
+{{- define "proxy.passthrough.isBigQuery" -}}
+{{- if include "proxy.passthrough.bigqueryUrl" . -}}true{{- end -}}
 {{- end -}}
 
 {{/* Env token for secret paths: staging→stg, production→prod, development→dev. */}}

--- a/charts/yuki/templates/_helpers.tpl
+++ b/charts/yuki/templates/_helpers.tpl
@@ -34,3 +34,13 @@
 INGESTION_KEY
 {{- end -}}
 {{- end -}}
+
+{{/* Snowflake account URL the passthrough forwards to, e.g. https://xyz.snowflakecomputing.com. */}}
+{{- define "proxy.passthrough.snowflakeUrl" -}}
+{{- .Values.passthrough.snowflakeHost | default .Values.app.container.env.PROXY_HOST -}}
+{{- end -}}
+
+{{/* Bare host[:port] for the Host header — Snowflake keys off this, not the scheme. */}}
+{{- define "proxy.passthrough.snowflakeHostHeader" -}}
+{{- (include "proxy.passthrough.snowflakeUrl" . | urlParse).host -}}
+{{- end -}}

--- a/charts/yuki/templates/ingress.yaml
+++ b/charts/yuki/templates/ingress.yaml
@@ -18,7 +18,11 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ .Values.app.name }}
+                name: {{ .Values.ingress.backend.serviceName | default .Values.app.name }}
                 port:
-                  number: {{ .Values.app.service.port }}
+                  {{- if .Values.ingress.backend.servicePortName }}
+                  name: {{ .Values.ingress.backend.servicePortName }}
+                  {{- else }}
+                  number: {{ .Values.ingress.backend.servicePortNumber | default .Values.app.service.port }}
+                  {{- end }}
 {{- end}}

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
 data:
   nginx.conf: |
     worker_processes 1;
+    pid /tmp/nginx.pid;
     events { worker_connections 1024; }
     http {
       # Snowflake's hostname is resolved once, at startup/reload, via the
@@ -30,6 +31,8 @@ data:
         location / {
           proxy_pass {{ include "proxy.passthrough.snowflakeUrl" . }};
           proxy_ssl_server_name on;
+          proxy_ssl_verify on;
+          proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
           proxy_set_header Host {{ include "proxy.passthrough.snowflakeHostHeader" . }};
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.passthrough.enabled -}}
-{{- if not (include "proxy.passthrough.snowflakeUrl" .) -}}
+{{- $snowflakeUrl := include "proxy.passthrough.snowflakeUrl" . -}}
+{{- if not $snowflakeUrl -}}
 {{- fail "passthrough.enabled is true but no Snowflake host is set — set passthrough.snowflakeHost or app.container.env.PROXY_HOST." -}}
+{{- end -}}
+{{- if not (or (hasPrefix "http://" $snowflakeUrl) (hasPrefix "https://" $snowflakeUrl)) -}}
+{{- fail (printf "passthrough Snowflake URL %q must include a scheme (https://...) or the Host header renders empty" $snowflakeUrl) -}}
 {{- end -}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -8,8 +8,8 @@
 {{- fail (printf "passthrough upstream URL %q must include a scheme (https://...) or the Host header renders empty" $upstreamUrl) -}}
 {{- end -}}
 {{- $upstreamParts := urlParse $upstreamUrl -}}
-{{- if or $upstreamParts.path $upstreamParts.query $upstreamParts.fragment -}}
-{{- fail (printf "passthrough upstream URL %q must be host-only (no path/query/fragment) — proxy_pass via $upstream doesn't rewrite the request URI" $upstreamUrl) -}}
+{{- if or (not $upstreamParts.host) $upstreamParts.path $upstreamParts.query $upstreamParts.fragment -}}
+{{- fail (printf "passthrough upstream URL %q must be a bare scheme://host with no path/query/fragment — proxy_pass via $upstream doesn't rewrite the request URI" $upstreamUrl) -}}
 {{- end -}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -21,7 +21,7 @@ data:
       # every chart deploy anyway. ponytail: revisit with an explicit
       # `resolver` + variable proxy_pass if Snowflake IP churn ever bites.
       server {
-        listen {{ .Values.passthrough.port }};
+        listen {{ .Values.app.service.port }};
 
         location /healthz {
           return 200 "ok";

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.passthrough.enabled -}}
+{{- if not (include "proxy.passthrough.snowflakeUrl" .) -}}
+{{- fail "passthrough.enabled is true but no Snowflake host is set — set passthrough.snowflakeHost or app.container.env.PROXY_HOST." -}}
+{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.app.name }}-passthrough
+  labels:
+    app: {{ .Values.app.name }}-passthrough
+    group: {{ .Values.app.group }}
+data:
+  nginx.conf: |
+    worker_processes 1;
+    events { worker_connections 1024; }
+    http {
+      # Snowflake's hostname is resolved once, at startup/reload, via the
+      # container's default resolver — no dynamic re-resolution. Fine for a
+      # bypass path that isn't the primary traffic route; pods recycle on
+      # every chart deploy anyway. ponytail: revisit with an explicit
+      # `resolver` + variable proxy_pass if Snowflake IP churn ever bites.
+      server {
+        listen {{ .Values.passthrough.port }};
+
+        location /healthz {
+          return 200 "ok";
+          add_header Content-Type text/plain;
+        }
+
+        location / {
+          proxy_pass {{ include "proxy.passthrough.snowflakeUrl" . }};
+          proxy_ssl_server_name on;
+          proxy_set_header Host {{ include "proxy.passthrough.snowflakeHostHeader" . }};
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_http_version 1.1;
+          proxy_set_header Connection "";
+          proxy_read_timeout 600s;
+          proxy_send_timeout 600s;
+        }
+      }
+    }
+{{- end }}

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.passthrough.enabled -}}
 {{- $upstreamUrl := include "proxy.passthrough.upstreamUrl" . -}}
-{{- $isBigQuery := include "proxy.passthrough.isBigQuery" . -}}
 {{- if not $upstreamUrl -}}
 {{- fail "passthrough.enabled is true but no upstream host is set — set passthrough.bigqueryHost/app.container.env.BIGQUERY_HOST or passthrough.snowflakeHost/app.container.env.PROXY_HOST." -}}
 {{- end -}}
@@ -51,13 +50,8 @@ data:
           proxy_ssl_server_name on;
           proxy_ssl_verify on;
           proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
-          {{- if $isBigQuery }}
-          # Client already targets the real BigQuery host — forward it unchanged.
-          proxy_set_header Host $http_host;
-          {{- else }}
-          # Client targets Yuki's hosted domain, not Snowflake's — rewrite to the real host.
-          proxy_set_header Host {{ include "proxy.passthrough.snowflakeHostHeader" . }};
-          {{- end }}
+          # Client targets Yuki's hosted domain, not the real upstream — rewrite to the real host.
+          proxy_set_header Host {{ include "proxy.passthrough.upstreamHostHeader" . }};
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_http_version 1.1;

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -27,6 +27,7 @@ data:
         listen {{ .Values.app.service.port }};
 
         location /healthz {
+          access_log off;
           return 200 "ok";
           add_header Content-Type text/plain;
         }

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -7,8 +7,9 @@
 {{- if not (or (hasPrefix "http://" $upstreamUrl) (hasPrefix "https://" $upstreamUrl)) -}}
 {{- fail (printf "passthrough upstream URL %q must include a scheme (https://...) or the Host header renders empty" $upstreamUrl) -}}
 {{- end -}}
-{{- if hasSuffix "/" $upstreamUrl -}}
-{{- fail (printf "passthrough upstream URL %q must not have a trailing slash — this changes proxy_pass URI rewriting" $upstreamUrl) -}}
+{{- $upstreamParts := urlParse $upstreamUrl -}}
+{{- if or $upstreamParts.path $upstreamParts.query $upstreamParts.fragment -}}
+{{- fail (printf "passthrough upstream URL %q must be host-only (no path/query/fragment) — proxy_pass via $upstream doesn't rewrite the request URI" $upstreamUrl) -}}
 {{- end -}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -6,6 +6,9 @@
 {{- if not (or (hasPrefix "http://" $snowflakeUrl) (hasPrefix "https://" $snowflakeUrl)) -}}
 {{- fail (printf "passthrough Snowflake URL %q must include a scheme (https://...) or the Host header renders empty" $snowflakeUrl) -}}
 {{- end -}}
+{{- if hasSuffix "/" $snowflakeUrl -}}
+{{- fail (printf "passthrough Snowflake URL %q must not have a trailing slash — this changes proxy_pass URI rewriting" $snowflakeUrl) -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -3,8 +3,8 @@
 {{- if not $upstreamUrl -}}
 {{- fail "passthrough.enabled is true but no upstream host is set — set passthrough.bigqueryHost/app.container.env.BIGQUERY_HOST or passthrough.snowflakeHost/app.container.env.PROXY_HOST." -}}
 {{- end -}}
-{{- if not (or (hasPrefix "http://" $upstreamUrl) (hasPrefix "https://" $upstreamUrl)) -}}
-{{- fail (printf "passthrough upstream URL %q must include a scheme (https://...) or the Host header renders empty" $upstreamUrl) -}}
+{{- if not (hasPrefix "https://" $upstreamUrl) -}}
+{{- fail (printf "passthrough upstream URL %q must be https:// — this proxies live Snowflake/BigQuery credentials and must not fall back to plaintext" $upstreamUrl) -}}
 {{- end -}}
 {{- $upstreamParts := urlParse $upstreamUrl -}}
 {{- if or (not $upstreamParts.host) $upstreamParts.path $upstreamParts.query $upstreamParts.fragment -}}

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -18,11 +18,13 @@ metadata:
     group: {{ .Values.app.group }}
 data:
   nginx.conf: |
-    worker_processes 1;
+    worker_processes auto;
     pid /tmp/nginx.pid;
     events { worker_connections 1024; }
     http {
-      # ponytail: DNS resolved once at startup, not dynamically re-resolved.
+      client_max_body_size 0;
+      # local=on reads /etc/resolv.conf so this works on any cluster's DNS, not just one CIDR.
+      resolver local=on valid=30s ipv6=off;
       server {
         listen {{ .Values.app.service.port }};
 
@@ -32,8 +34,17 @@ data:
           add_header Content-Type text/plain;
         }
 
+        # ALB target-group health check — must answer directly, not fall through to Snowflake.
+        location = /health/live {
+          access_log off;
+          return 200 "ok";
+          add_header Content-Type text/plain;
+        }
+
         location / {
-          proxy_pass {{ include "proxy.passthrough.snowflakeUrl" . }};
+          # $upstream forces periodic re-resolution; a literal proxy_pass target is resolved once at startup.
+          set $upstream {{ include "proxy.passthrough.snowflakeUrl" . }};
+          proxy_pass $upstream;
           proxy_ssl_server_name on;
           proxy_ssl_verify on;
           proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -1,13 +1,14 @@
 {{- if .Values.passthrough.enabled -}}
-{{- $snowflakeUrl := include "proxy.passthrough.snowflakeUrl" . -}}
-{{- if not $snowflakeUrl -}}
-{{- fail "passthrough.enabled is true but no Snowflake host is set — set passthrough.snowflakeHost or app.container.env.PROXY_HOST." -}}
+{{- $upstreamUrl := include "proxy.passthrough.upstreamUrl" . -}}
+{{- $isBigQuery := include "proxy.passthrough.isBigQuery" . -}}
+{{- if not $upstreamUrl -}}
+{{- fail "passthrough.enabled is true but no upstream host is set — set passthrough.bigqueryHost/app.container.env.BIGQUERY_HOST or passthrough.snowflakeHost/app.container.env.PROXY_HOST." -}}
 {{- end -}}
-{{- if not (or (hasPrefix "http://" $snowflakeUrl) (hasPrefix "https://" $snowflakeUrl)) -}}
-{{- fail (printf "passthrough Snowflake URL %q must include a scheme (https://...) or the Host header renders empty" $snowflakeUrl) -}}
+{{- if not (or (hasPrefix "http://" $upstreamUrl) (hasPrefix "https://" $upstreamUrl)) -}}
+{{- fail (printf "passthrough upstream URL %q must include a scheme (https://...) or the Host header renders empty" $upstreamUrl) -}}
 {{- end -}}
-{{- if hasSuffix "/" $snowflakeUrl -}}
-{{- fail (printf "passthrough Snowflake URL %q must not have a trailing slash — this changes proxy_pass URI rewriting" $snowflakeUrl) -}}
+{{- if hasSuffix "/" $upstreamUrl -}}
+{{- fail (printf "passthrough upstream URL %q must not have a trailing slash — this changes proxy_pass URI rewriting" $upstreamUrl) -}}
 {{- end -}}
 apiVersion: v1
 kind: ConfigMap
@@ -44,12 +45,18 @@ data:
 
         location / {
           # $upstream forces periodic re-resolution; a literal proxy_pass target is resolved once at startup.
-          set $upstream {{ include "proxy.passthrough.snowflakeUrl" . }};
+          set $upstream {{ $upstreamUrl }};
           proxy_pass $upstream;
           proxy_ssl_server_name on;
           proxy_ssl_verify on;
           proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+          {{- if $isBigQuery }}
+          # Client already targets the real BigQuery host — forward it unchanged.
+          proxy_set_header Host $http_host;
+          {{- else }}
+          # Client targets Yuki's hosted domain, not Snowflake's — rewrite to the real host.
           proxy_set_header Host {{ include "proxy.passthrough.snowflakeHostHeader" . }};
+          {{- end }}
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_http_version 1.1;

--- a/charts/yuki/templates/passthrough-configmap.yaml
+++ b/charts/yuki/templates/passthrough-configmap.yaml
@@ -17,14 +17,15 @@ metadata:
     app: {{ .Values.app.name }}-passthrough
     group: {{ .Values.app.group }}
 data:
-  nginx.conf: |
+  # __RESOLVER_IP__ is substituted at container start from /etc/resolv.conf — stock nginx has
+  # no "read resolv.conf yourself" option (that's an OpenResty-only extension).
+  nginx.conf.template: |
     worker_processes auto;
     pid /tmp/nginx.pid;
     events { worker_connections 1024; }
     http {
       client_max_body_size 0;
-      # local=on reads /etc/resolv.conf so this works on any cluster's DNS, not just one CIDR.
-      resolver local=on valid=30s ipv6=off;
+      resolver __RESOLVER_IP__ valid=30s ipv6=off;
       server {
         listen {{ .Values.app.service.port }};
 

--- a/charts/yuki/templates/passthrough-deployment.yaml
+++ b/charts/yuki/templates/passthrough-deployment.yaml
@@ -38,7 +38,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           ports:
-            - containerPort: {{ .Values.passthrough.port }}
+            - containerPort: {{ .Values.app.service.port }}
           volumeMounts:
             - name: nginx-conf
               mountPath: /etc/nginx/nginx.conf
@@ -54,14 +54,14 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.passthrough.port }}
+              port: {{ .Values.app.service.port }}
             periodSeconds: 10
             timeoutSeconds: 1
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.passthrough.port }}
+              port: {{ .Values.app.service.port }}
             periodSeconds: 5
             timeoutSeconds: 1
             failureThreshold: 1

--- a/charts/yuki/templates/passthrough-deployment.yaml
+++ b/charts/yuki/templates/passthrough-deployment.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.passthrough.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.app.name }}-passthrough
+  labels:
+    app: {{ .Values.app.name }}-passthrough
+    group: {{ .Values.app.group }}
+spec:
+  replicas: {{ .Values.passthrough.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Values.app.name }}-passthrough
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.app.name }}-passthrough
+        group: {{ .Values.app.group }}
+    spec:
+      terminationGracePeriodSeconds: 15
+      containers:
+        - name: passthrough
+          image: {{ .Values.passthrough.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.passthrough.port }}
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          {{- with .Values.passthrough.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.passthrough.port }}
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.passthrough.port }}
+            periodSeconds: 5
+            timeoutSeconds: 1
+            failureThreshold: 1
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: {{ .Values.app.name }}-passthrough
+{{- end }}

--- a/charts/yuki/templates/passthrough-deployment.yaml
+++ b/charts/yuki/templates/passthrough-deployment.yaml
@@ -20,12 +20,6 @@ spec:
         group: {{ .Values.app.group }}
     spec:
       terminationGracePeriodSeconds: 15
-      {{- if and .Values.passthrough.watcher.enabled (not .Values.passthrough.mode) }}
-      {{- fail "passthrough.mode must be set (auto/forcePassthrough/forceProxy) when passthrough.watcher.enabled is true" }}
-      {{- end }}
-      {{- if .Values.passthrough.watcher.enabled }}
-      serviceAccountName: {{ .Values.app.name }}-passthrough-watcher
-      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 101
@@ -71,26 +65,6 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh", "-c", "sleep 5"]
-        {{- if .Values.passthrough.watcher.enabled }}
-        - name: watcher
-          image: {{ .Values.passthrough.watcher.image }}
-          imagePullPolicy: IfNotPresent
-          command: ["/bin/sh", "/etc/bypass/watch.sh"]
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
-          volumeMounts:
-            - name: watcher-config
-              mountPath: /etc/bypass
-          resources:
-            requests:
-              cpu: "10m"
-              memory: "16Mi"
-            limits:
-              memory: "32Mi"
-        {{- end }}
       volumes:
         - name: nginx-conf
           configMap:
@@ -101,9 +75,4 @@ spec:
         - name: tmp
           emptyDir:
             sizeLimit: 16Mi
-        {{- if .Values.passthrough.watcher.enabled }}
-        - name: watcher-config
-          configMap:
-            name: {{ .Values.app.name }}-passthrough-watcher
-        {{- end }}
 {{- end }}

--- a/charts/yuki/templates/passthrough-deployment.yaml
+++ b/charts/yuki/templates/passthrough-deployment.yaml
@@ -18,16 +18,29 @@ spec:
         group: {{ .Values.app.group }}
     spec:
       terminationGracePeriodSeconds: 15
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
       containers:
         - name: passthrough
           image: {{ .Values.passthrough.image }}
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           ports:
             - containerPort: {{ .Values.passthrough.port }}
           volumeMounts:
             - name: nginx-conf
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
+            - name: cache
+              mountPath: /var/cache/nginx
+            - name: tmp
+              mountPath: /tmp
           {{- with .Values.passthrough.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -54,4 +67,8 @@ spec:
         - name: nginx-conf
           configMap:
             name: {{ .Values.app.name }}-passthrough
+        - name: cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
 {{- end }}

--- a/charts/yuki/templates/passthrough-deployment.yaml
+++ b/charts/yuki/templates/passthrough-deployment.yaml
@@ -7,7 +7,9 @@ metadata:
     app: {{ .Values.app.name }}-passthrough
     group: {{ .Values.app.group }}
 spec:
+  {{- if not .Values.passthrough.hpa.enabled }}
   replicas: {{ .Values.passthrough.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.app.name }}-passthrough

--- a/charts/yuki/templates/passthrough-deployment.yaml
+++ b/charts/yuki/templates/passthrough-deployment.yaml
@@ -68,7 +68,9 @@ spec:
           configMap:
             name: {{ .Values.app.name }}-passthrough
         - name: cache
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 64Mi
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 16Mi
 {{- end }}

--- a/charts/yuki/templates/passthrough-deployment.yaml
+++ b/charts/yuki/templates/passthrough-deployment.yaml
@@ -18,6 +18,12 @@ spec:
         group: {{ .Values.app.group }}
     spec:
       terminationGracePeriodSeconds: 15
+      {{- if and .Values.passthrough.watcher.enabled (not .Values.passthrough.mode) }}
+      {{- fail "passthrough.mode must be set (auto/forcePassthrough/forceProxy) when passthrough.watcher.enabled is true" }}
+      {{- end }}
+      {{- if .Values.passthrough.watcher.enabled }}
+      serviceAccountName: {{ .Values.app.name }}-passthrough-watcher
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 101
@@ -63,6 +69,26 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh", "-c", "sleep 5"]
+        {{- if .Values.passthrough.watcher.enabled }}
+        - name: watcher
+          image: {{ .Values.passthrough.watcher.image }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/etc/bypass/watch.sh"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: watcher-config
+              mountPath: /etc/bypass
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              memory: "32Mi"
+        {{- end }}
       volumes:
         - name: nginx-conf
           configMap:
@@ -73,4 +99,9 @@ spec:
         - name: tmp
           emptyDir:
             sizeLimit: 16Mi
+        {{- if .Values.passthrough.watcher.enabled }}
+        - name: watcher-config
+          configMap:
+            name: {{ .Values.app.name }}-passthrough-watcher
+        {{- end }}
 {{- end }}

--- a/charts/yuki/templates/passthrough-deployment.yaml
+++ b/charts/yuki/templates/passthrough-deployment.yaml
@@ -33,12 +33,19 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              resolver_ip=$(awk '/^nameserver/{print $2; exit}' /etc/resolv.conf)
+              sed "s/__RESOLVER_IP__/$resolver_ip/" /etc/nginx/nginx.conf.template > /tmp/nginx.conf
+              exec nginx -c /tmp/nginx.conf -g "daemon off;"
           ports:
             - containerPort: {{ .Values.app.service.port }}
           volumeMounts:
             - name: nginx-conf
-              mountPath: /etc/nginx/nginx.conf
-              subPath: nginx.conf
+              mountPath: /etc/nginx/nginx.conf.template
+              subPath: nginx.conf.template
             - name: cache
               mountPath: /var/cache/nginx
             - name: tmp

--- a/charts/yuki/templates/passthrough-hpa.yaml
+++ b/charts/yuki/templates/passthrough-hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.passthrough.enabled .Values.passthrough.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.app.name }}-passthrough
+  labels:
+    app: {{ .Values.app.name }}-passthrough
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.app.name }}-passthrough
+  minReplicas: {{ .Values.passthrough.hpa.minReplicas }}
+  maxReplicas: {{ .Values.passthrough.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.passthrough.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.passthrough.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/charts/yuki/templates/passthrough-service.yaml
+++ b/charts/yuki/templates/passthrough-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.passthrough.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.name }}-passthrough
+  labels:
+    app: {{ .Values.app.name }}-passthrough
+    group: {{ .Values.app.group }}
+spec:
+  type: {{ .Values.passthrough.service.type }}
+  selector:
+    app: {{ .Values.app.name }}-passthrough
+  ports:
+    - name: app
+      port: {{ .Values.passthrough.service.port }}
+      targetPort: {{ .Values.passthrough.port }}
+{{- end }}

--- a/charts/yuki/templates/passthrough-service.yaml
+++ b/charts/yuki/templates/passthrough-service.yaml
@@ -12,6 +12,6 @@ spec:
     app: {{ .Values.app.name }}-passthrough
   ports:
     - name: app
-      port: {{ .Values.passthrough.service.port }}
-      targetPort: {{ .Values.passthrough.port }}
+      port: {{ .Values.app.service.port }}
+      targetPort: {{ .Values.app.service.port }}
 {{- end }}

--- a/charts/yuki/templates/passthrough-watcher-configmap.yaml
+++ b/charts/yuki/templates/passthrough-watcher-configmap.yaml
@@ -80,9 +80,13 @@ data:
         continue
       fi
       if [ "$current" != "$PROXY_LABEL" ] && [ "$current" != "$PASSTHROUGH_LABEL" ]; then
-        echo "$(date -Iseconds) bypass-watcher: unexpected selector '$current'; resetting to $PROXY_LABEL"
-        patch_selector "$PROXY_LABEL" || true
-        current="$PROXY_LABEL"
+        # Reset toward whatever the active mode wants, not always the proxy — resetting
+        # to the proxy first while forcePassthrough is active would defeat the override.
+        reset_target="$PROXY_LABEL"
+        [ "$mode" = "forcePassthrough" ] && reset_target="$PASSTHROUGH_LABEL"
+        echo "$(date -Iseconds) bypass-watcher: unexpected selector '$current'; resetting to $reset_target"
+        patch_selector "$reset_target" || true
+        current="$reset_target"
       fi
 
       if [ "$mode" = "forcePassthrough" ]; then

--- a/charts/yuki/templates/passthrough-watcher-configmap.yaml
+++ b/charts/yuki/templates/passthrough-watcher-configmap.yaml
@@ -30,9 +30,10 @@ data:
       curl -sS --cacert "$CA_FILE" -H "Authorization: Bearer $(cat $TOKEN_FILE)" "$@"
     }
 
-    # ponytail: grep/cut, not jq — API server pretty-prints, so match loosely.
+    # ponytail: sed, not jq — scoped to spec.selector so metadata.labels.app doesn't match first.
     current_selector_label() {
-      k8s_curl "$SVC_URL" | grep -o '"app": *"[^"]*"' | head -1 | cut -d'"' -f4
+      k8s_curl "$SVC_URL" | tr -d '\n' \
+        | sed -n 's/.*"selector"[[:space:]]*:[[:space:]]*{[^}]*"app"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
     }
 
     patch_selector() {
@@ -46,7 +47,8 @@ data:
 
     current=$(current_selector_label)
     if [ "$current" != "$PROXY_LABEL" ] && [ "$current" != "$PASSTHROUGH_LABEL" ]; then
-      echo "$(date -Iseconds) bypass-watcher: unexpected initial selector '$current'; assuming $PROXY_LABEL"
+      echo "$(date -Iseconds) bypass-watcher: unexpected initial selector '$current'; resetting to $PROXY_LABEL"
+      patch_selector "$PROXY_LABEL"
       current="$PROXY_LABEL"
     fi
     fail_count=0

--- a/charts/yuki/templates/passthrough-watcher-configmap.yaml
+++ b/charts/yuki/templates/passthrough-watcher-configmap.yaml
@@ -33,8 +33,9 @@ data:
 
     # ponytail: grep/cut instead of a JSON parser — we control the exact response
     # shape (our own Service), so this is fine; swap for jq if that ever changes.
+    # The API server pretty-prints (space after ':'), so match that loosely.
     current_selector_label() {
-      k8s_curl "$SVC_URL" | grep -o '"app":"[^"]*"' | head -1 | cut -d'"' -f4
+      k8s_curl "$SVC_URL" | grep -o '"app": *"[^"]*"' | head -1 | cut -d'"' -f4
     }
 
     patch_selector() {
@@ -47,6 +48,10 @@ data:
     }
 
     current=$(current_selector_label)
+    if [ "$current" != "$PROXY_LABEL" ] && [ "$current" != "$PASSTHROUGH_LABEL" ]; then
+      echo "$(date -Iseconds) unexpected initial selector '$current'; assuming $PROXY_LABEL"
+      current="$PROXY_LABEL"
+    fi
     fail_count=0
     success_count=0
 

--- a/charts/yuki/templates/passthrough-watcher-configmap.yaml
+++ b/charts/yuki/templates/passthrough-watcher-configmap.yaml
@@ -51,31 +51,43 @@ data:
 
     current=$(current_selector_label)
     if [ "$current" != "$PROXY_LABEL" ] && [ "$current" != "$PASSTHROUGH_LABEL" ]; then
-      echo "$(date -Iseconds) unexpected initial selector '$current'; assuming $PROXY_LABEL"
+      echo "$(date -Iseconds) bypass-watcher: unexpected initial selector '$current'; assuming $PROXY_LABEL"
       current="$PROXY_LABEL"
     fi
     fail_count=0
     success_count=0
+    echo "$(date -Iseconds) bypass-watcher: started, mode=$(cat /etc/bypass/mode 2>/dev/null || echo auto) current=$current health_url=$HEALTH_URL"
 
     while true; do
       mode=$(cat /etc/bypass/mode 2>/dev/null || echo auto)
 
       if [ "$mode" = "forcePassthrough" ]; then
-        [ "$current" = "$PASSTHROUGH_LABEL" ] || { patch_selector "$PASSTHROUGH_LABEL"; current=$PASSTHROUGH_LABEL; }
+        if [ "$current" != "$PASSTHROUGH_LABEL" ]; then
+          echo "$(date -Iseconds) bypass-watcher: mode=forcePassthrough, switching $current -> $PASSTHROUGH_LABEL"
+          patch_selector "$PASSTHROUGH_LABEL"; current=$PASSTHROUGH_LABEL
+        fi
         fail_count=0; success_count=0
       elif [ "$mode" = "forceProxy" ]; then
-        [ "$current" = "$PROXY_LABEL" ] || { patch_selector "$PROXY_LABEL"; current=$PROXY_LABEL; }
+        if [ "$current" != "$PROXY_LABEL" ]; then
+          echo "$(date -Iseconds) bypass-watcher: mode=forceProxy, switching $current -> $PROXY_LABEL"
+          patch_selector "$PROXY_LABEL"; current=$PROXY_LABEL
+        fi
         fail_count=0; success_count=0
       else
         if curl -sf -o /dev/null -m 3 "$HEALTH_URL"; then
           success_count=$((success_count + 1)); fail_count=0
+          health=healthy
         else
           fail_count=$((fail_count + 1)); success_count=0
+          health=unhealthy
         fi
+        echo "$(date -Iseconds) bypass-watcher: poll proxy=$health current=$current fail=$fail_count/$FAILURE_THRESHOLD success=$success_count/$SUCCESS_THRESHOLD"
 
         if [ "$current" = "$PROXY_LABEL" ] && [ "$fail_count" -ge "$FAILURE_THRESHOLD" ]; then
+          echo "$(date -Iseconds) bypass-watcher: failure threshold reached, switching $PROXY_LABEL -> $PASSTHROUGH_LABEL"
           patch_selector "$PASSTHROUGH_LABEL"; current=$PASSTHROUGH_LABEL; fail_count=0
         elif [ "$current" = "$PASSTHROUGH_LABEL" ] && [ "$success_count" -ge "$SUCCESS_THRESHOLD" ]; then
+          echo "$(date -Iseconds) bypass-watcher: success threshold reached, reverting $PASSTHROUGH_LABEL -> $PROXY_LABEL"
           patch_selector "$PROXY_LABEL"; current=$PROXY_LABEL; success_count=0
         fi
       fi

--- a/charts/yuki/templates/passthrough-watcher-configmap.yaml
+++ b/charts/yuki/templates/passthrough-watcher-configmap.yaml
@@ -78,7 +78,11 @@ data:
           fail_count=$((fail_count + 1)); success_count=0
           health=unhealthy
         fi
-        echo "$(date -Iseconds) bypass-watcher: poll proxy=$health current=$current fail=$fail_count/$FAILURE_THRESHOLD success=$success_count/$SUCCESS_THRESHOLD"
+        # Quiet in the steady state (healthy, on proxy, nothing happening) — every
+        # poll logs otherwise: any failure, or anything while on the passthrough.
+        if [ "$health" = "unhealthy" ] || [ "$current" != "$PROXY_LABEL" ]; then
+          echo "$(date -Iseconds) bypass-watcher: poll proxy=$health current=$current fail=$fail_count/$FAILURE_THRESHOLD success=$success_count/$SUCCESS_THRESHOLD"
+        fi
 
         if [ "$current" = "$PROXY_LABEL" ] && [ "$fail_count" -ge "$FAILURE_THRESHOLD" ]; then
           echo "$(date -Iseconds) bypass-watcher: failure threshold reached, switching $PROXY_LABEL -> $PASSTHROUGH_LABEL"

--- a/charts/yuki/templates/passthrough-watcher-configmap.yaml
+++ b/charts/yuki/templates/passthrough-watcher-configmap.yaml
@@ -11,7 +11,7 @@ data:
   mode: {{ .Values.passthrough.mode | quote }}
   watch.sh: |
     #!/bin/sh
-    set -eu
+    set -eu -o pipefail
 
     NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
     TOKEN_FILE=/var/run/secrets/kubernetes.io/serviceaccount/token
@@ -25,49 +25,76 @@ data:
     FAILURE_THRESHOLD={{ .Values.passthrough.watcher.failureThreshold }}
     SUCCESS_THRESHOLD={{ .Values.passthrough.watcher.successThreshold }}
     POLL_INTERVAL={{ .Values.passthrough.watcher.pollIntervalSeconds }}
+    HEARTBEAT_FILE=/tmp/heartbeat
 
     k8s_curl() {
-      curl -sS --cacert "$CA_FILE" -H "Authorization: Bearer $(cat $TOKEN_FILE)" "$@"
+      curl -sS --max-time 10 --retry 1 --cacert "$CA_FILE" -H "Authorization: Bearer $(cat $TOKEN_FILE)" "$@"
     }
 
     # ponytail: sed, not jq — scoped to spec.selector so metadata.labels.app doesn't match first.
     current_selector_label() {
-      k8s_curl "$SVC_URL" | tr -d '\n' \
+      k8s_curl -f "$SVC_URL" | tr -d '\n' \
         | sed -n 's/.*"selector"[[:space:]]*:[[:space:]]*{[^}]*"app"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+    }
+
+    # Retries transient failures; only returns non-zero once retries are exhausted, so
+    # the caller can tell "couldn't read" apart from "read something unexpected".
+    read_selector() {
+      attempt=0
+      while [ "$attempt" -lt 3 ]; do
+        if label=$(current_selector_label); then
+          printf '%s' "$label"
+          return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 1
+      done
+      return 1
     }
 
     patch_selector() {
       label="$1"
-      k8s_curl -X PATCH \
+      if ! k8s_curl -f -X PATCH \
         -H "Content-Type: application/strategic-merge-patch+json" \
         -d "{\"spec\":{\"selector\":{\"app\":\"$label\"}}}" \
-        "$SVC_URL" >/dev/null
+        "$SVC_URL" >/dev/null; then
+        echo "$(date -Iseconds) bypass-watcher: PATCH to app=$label failed" >&2
+        return 1
+      fi
       echo "$(date -Iseconds) switched proxy Service to app=$label"
     }
 
-    current=$(current_selector_label)
-    if [ "$current" != "$PROXY_LABEL" ] && [ "$current" != "$PASSTHROUGH_LABEL" ]; then
-      echo "$(date -Iseconds) bypass-watcher: unexpected initial selector '$current'; resetting to $PROXY_LABEL"
-      patch_selector "$PROXY_LABEL"
-      current="$PROXY_LABEL"
-    fi
     fail_count=0
     success_count=0
-    echo "$(date -Iseconds) bypass-watcher: started, mode=$(cat /etc/bypass/mode 2>/dev/null || echo auto) current=$current health_url=$HEALTH_URL"
+    echo "$(date -Iseconds) bypass-watcher: started, mode=$(cat /etc/bypass/mode 2>/dev/null || echo auto) health_url=$HEALTH_URL"
 
     while true; do
       mode=$(cat /etc/bypass/mode 2>/dev/null || echo auto)
 
+      # Re-read the real Service each loop instead of trusting an in-memory value —
+      # a stale/wrong belief here is worse than one extra API call per poll.
+      if ! current=$(read_selector); then
+        echo "$(date -Iseconds) bypass-watcher: could not read Service selector after retries, skipping this cycle"
+        touch "$HEARTBEAT_FILE"
+        sleep "$POLL_INTERVAL"
+        continue
+      fi
+      if [ "$current" != "$PROXY_LABEL" ] && [ "$current" != "$PASSTHROUGH_LABEL" ]; then
+        echo "$(date -Iseconds) bypass-watcher: unexpected selector '$current'; resetting to $PROXY_LABEL"
+        patch_selector "$PROXY_LABEL" || true
+        current="$PROXY_LABEL"
+      fi
+
       if [ "$mode" = "forcePassthrough" ]; then
         if [ "$current" != "$PASSTHROUGH_LABEL" ]; then
           echo "$(date -Iseconds) bypass-watcher: mode=forcePassthrough, switching $current -> $PASSTHROUGH_LABEL"
-          patch_selector "$PASSTHROUGH_LABEL"; current=$PASSTHROUGH_LABEL
+          patch_selector "$PASSTHROUGH_LABEL" || true
         fi
         fail_count=0; success_count=0
       elif [ "$mode" = "forceProxy" ]; then
         if [ "$current" != "$PROXY_LABEL" ]; then
           echo "$(date -Iseconds) bypass-watcher: mode=forceProxy, switching $current -> $PROXY_LABEL"
-          patch_selector "$PROXY_LABEL"; current=$PROXY_LABEL
+          patch_selector "$PROXY_LABEL" || true
         fi
         fail_count=0; success_count=0
       else
@@ -86,13 +113,17 @@ data:
 
         if [ "$current" = "$PROXY_LABEL" ] && [ "$fail_count" -ge "$FAILURE_THRESHOLD" ]; then
           echo "$(date -Iseconds) bypass-watcher: failure threshold reached, switching $PROXY_LABEL -> $PASSTHROUGH_LABEL"
-          patch_selector "$PASSTHROUGH_LABEL"; current=$PASSTHROUGH_LABEL; fail_count=0
+          patch_selector "$PASSTHROUGH_LABEL" || true
+          fail_count=0
         elif [ "$current" = "$PASSTHROUGH_LABEL" ] && [ "$success_count" -ge "$SUCCESS_THRESHOLD" ]; then
           echo "$(date -Iseconds) bypass-watcher: success threshold reached, reverting $PASSTHROUGH_LABEL -> $PROXY_LABEL"
-          patch_selector "$PROXY_LABEL"; current=$PROXY_LABEL; success_count=0
+          patch_selector "$PROXY_LABEL" || true
+          success_count=0
         fi
       fi
 
+      # Liveness probe checks this file's mtime — a hang anywhere above stops it updating.
+      touch "$HEARTBEAT_FILE"
       sleep "$POLL_INTERVAL"
     done
 {{- end }}

--- a/charts/yuki/templates/passthrough-watcher-configmap.yaml
+++ b/charts/yuki/templates/passthrough-watcher-configmap.yaml
@@ -1,0 +1,78 @@
+{{- if and .Values.passthrough.enabled .Values.passthrough.watcher.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.app.name }}-passthrough-watcher
+  labels:
+    app: {{ .Values.app.name }}-passthrough
+    group: {{ .Values.app.group }}
+data:
+  # Read fresh every loop iteration so a values change (mode: auto/forceProxy/
+  # forcePassthrough) propagates within one poll interval — no pod restart needed,
+  # since kubelet updates mounted ConfigMap files in place on change.
+  mode: {{ .Values.passthrough.mode | quote }}
+  watch.sh: |
+    #!/bin/sh
+    set -eu
+
+    NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+    TOKEN_FILE=/var/run/secrets/kubernetes.io/serviceaccount/token
+    CA_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    API=https://kubernetes.default.svc
+    SVC_URL="$API/api/v1/namespaces/$NAMESPACE/services/{{ .Values.app.name }}"
+    HEALTH_URL="http://{{ .Values.app.name }}:{{ .Values.app.service.port }}{{ .Values.passthrough.watcher.healthPath }}"
+    PROXY_LABEL="{{ .Values.app.name }}"
+    PASSTHROUGH_LABEL="{{ .Values.app.name }}-passthrough"
+    FAILURE_THRESHOLD={{ .Values.passthrough.watcher.failureThreshold }}
+    SUCCESS_THRESHOLD={{ .Values.passthrough.watcher.successThreshold }}
+    POLL_INTERVAL={{ .Values.passthrough.watcher.pollIntervalSeconds }}
+
+    k8s_curl() {
+      curl -sS --cacert "$CA_FILE" -H "Authorization: Bearer $(cat $TOKEN_FILE)" "$@"
+    }
+
+    # ponytail: grep/cut instead of a JSON parser — we control the exact response
+    # shape (our own Service), so this is fine; swap for jq if that ever changes.
+    current_selector_label() {
+      k8s_curl "$SVC_URL" | grep -o '"app":"[^"]*"' | head -1 | cut -d'"' -f4
+    }
+
+    patch_selector() {
+      label="$1"
+      k8s_curl -X PATCH \
+        -H "Content-Type: application/strategic-merge-patch+json" \
+        -d "{\"spec\":{\"selector\":{\"app\":\"$label\"}}}" \
+        "$SVC_URL" >/dev/null
+      echo "$(date -Iseconds) switched proxy Service to app=$label"
+    }
+
+    current=$(current_selector_label)
+    fail_count=0
+    success_count=0
+
+    while true; do
+      mode=$(cat /etc/bypass/mode 2>/dev/null || echo auto)
+
+      if [ "$mode" = "forcePassthrough" ]; then
+        [ "$current" = "$PASSTHROUGH_LABEL" ] || { patch_selector "$PASSTHROUGH_LABEL"; current=$PASSTHROUGH_LABEL; }
+        fail_count=0; success_count=0
+      elif [ "$mode" = "forceProxy" ]; then
+        [ "$current" = "$PROXY_LABEL" ] || { patch_selector "$PROXY_LABEL"; current=$PROXY_LABEL; }
+        fail_count=0; success_count=0
+      else
+        if curl -sf -o /dev/null -m 3 "$HEALTH_URL"; then
+          success_count=$((success_count + 1)); fail_count=0
+        else
+          fail_count=$((fail_count + 1)); success_count=0
+        fi
+
+        if [ "$current" = "$PROXY_LABEL" ] && [ "$fail_count" -ge "$FAILURE_THRESHOLD" ]; then
+          patch_selector "$PASSTHROUGH_LABEL"; current=$PASSTHROUGH_LABEL; fail_count=0
+        elif [ "$current" = "$PASSTHROUGH_LABEL" ] && [ "$success_count" -ge "$SUCCESS_THRESHOLD" ]; then
+          patch_selector "$PROXY_LABEL"; current=$PROXY_LABEL; success_count=0
+        fi
+      fi
+
+      sleep "$POLL_INTERVAL"
+    done
+{{- end }}

--- a/charts/yuki/templates/passthrough-watcher-configmap.yaml
+++ b/charts/yuki/templates/passthrough-watcher-configmap.yaml
@@ -20,7 +20,9 @@ data:
     CA_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     API=https://kubernetes.default.svc
     SVC_URL="$API/api/v1/namespaces/$NAMESPACE/services/{{ .Values.app.name }}"
-    HEALTH_URL="http://{{ .Values.app.name }}:{{ .Values.app.service.port }}{{ .Values.passthrough.watcher.healthPath }}"
+    # Deliberately NOT the {{ .Values.app.name }} Service above — that's the one we
+    # swap, so checking health through it would be circular once passthrough is active.
+    HEALTH_URL="http://{{ .Values.app.name }}-direct:{{ .Values.app.service.port }}{{ .Values.passthrough.watcher.healthPath }}"
     PROXY_LABEL="{{ .Values.app.name }}"
     PASSTHROUGH_LABEL="{{ .Values.app.name }}-passthrough"
     FAILURE_THRESHOLD={{ .Values.passthrough.watcher.failureThreshold }}

--- a/charts/yuki/templates/passthrough-watcher-deployment.yaml
+++ b/charts/yuki/templates/passthrough-watcher-deployment.yaml
@@ -42,8 +42,10 @@ spec:
             - name: tmp
               mountPath: /tmp
           livenessProbe:
+            # ponytail: 3m window — worst case a loop iteration burns ~65s on curl retries
+            # (2x reads x up to 2x(10s timeout+1 retry) + sleeps), so 1m was too tight.
             exec:
-              command: ["sh", "-c", "test -n \"$(find /tmp/heartbeat -mmin -1 2>/dev/null)\""]
+              command: ["sh", "-c", "test -n \"$(find /tmp/heartbeat -mmin -3 2>/dev/null)\""]
             initialDelaySeconds: 10
             periodSeconds: 15
             failureThreshold: 2

--- a/charts/yuki/templates/passthrough-watcher-deployment.yaml
+++ b/charts/yuki/templates/passthrough-watcher-deployment.yaml
@@ -1,0 +1,63 @@
+{{- if and .Values.passthrough.enabled .Values.passthrough.watcher.enabled -}}
+{{- if not .Values.passthrough.mode }}
+{{- fail "passthrough.mode must be set (auto/forcePassthrough/forceProxy) when passthrough.watcher.enabled is true" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.app.name }}-passthrough-watcher
+  labels:
+    app: {{ .Values.app.name }}-passthrough-watcher
+    group: {{ .Values.app.group }}
+spec:
+  # Single instance by design — one controller deciding the Service selector, not one per passthrough pod.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.app.name }}-passthrough-watcher
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.app.name }}-passthrough-watcher
+        group: {{ .Values.app.group }}
+    spec:
+      serviceAccountName: {{ .Values.app.name }}-passthrough-watcher
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+      containers:
+        - name: watcher
+          image: {{ .Values.passthrough.watcher.image }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/etc/bypass/watch.sh"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: watcher-config
+              mountPath: /etc/bypass
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "test -n \"$(find /tmp/heartbeat -mmin -1 2>/dev/null)\""]
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              memory: "32Mi"
+      volumes:
+        - name: watcher-config
+          configMap:
+            name: {{ .Values.app.name }}-passthrough-watcher
+        - name: tmp
+          emptyDir:
+            sizeLimit: 4Mi
+{{- end }}

--- a/charts/yuki/templates/passthrough-watcher-direct-service.yaml
+++ b/charts/yuki/templates/passthrough-watcher-direct-service.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.passthrough.enabled .Values.passthrough.watcher.enabled -}}
+# Stable, never-swapped Service pointing at the real proxy pods, used only so the
+# watcher can health-check the proxy directly — checking through the main
+# {{ .Values.app.name }} Service would be circular once it's swapped to passthrough.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.name }}-direct
+  labels:
+    app: {{ .Values.app.name }}-passthrough
+    group: {{ .Values.app.group }}
+spec:
+  selector:
+    app: {{ .Values.app.name }}
+  ports:
+    - name: app
+      port: {{ .Values.app.service.port }}
+      targetPort: {{ .Values.app.container.port }}
+{{- end }}

--- a/charts/yuki/templates/passthrough-watcher-rbac.yaml
+++ b/charts/yuki/templates/passthrough-watcher-rbac.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.passthrough.enabled .Values.passthrough.watcher.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.app.name }}-passthrough-watcher
+  labels:
+    app: {{ .Values.app.name }}-passthrough
+    group: {{ .Values.app.group }}
+---
+# Scoped to exactly what the watcher does: read and patch the proxy's own Service.
+# Nothing else in the cluster is reachable with this identity.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.app.name }}-passthrough-watcher
+  labels:
+    app: {{ .Values.app.name }}-passthrough
+    group: {{ .Values.app.group }}
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["{{ .Values.app.name }}"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.app.name }}-passthrough-watcher
+  labels:
+    app: {{ .Values.app.name }}-passthrough
+    group: {{ .Values.app.group }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.app.name }}-passthrough-watcher
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.app.name }}-passthrough-watcher
+{{- end }}

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -89,6 +89,30 @@ proxyDeploymentType: self_hosted
 ingress:
   enabled: false
 
+# Minimal, dependency-free fallback that forwards straight to Snowflake with
+# the correct Host header — a bypass path for when Yuki Proxy (or one of its
+# dependencies) is unhealthy. Off by default and not wired into `ingress` yet;
+# that wiring (weighted ALB target groups) is separate infra-repo work.
+# See the "Yuki Proxy Bypass Options" design doc for the full rationale.
+passthrough:
+  enabled: false
+  replicaCount: 2
+  image: nginx:1.27-alpine
+  port: 8080
+  # Snowflake account URL to forward to, e.g. "https://xyz.snowflakecomputing.com".
+  # Defaults to the same host Yuki Proxy itself targets (app.container.env.PROXY_HOST)
+  # so there's one source of truth; override only if they should ever differ.
+  snowflakeHost: ""
+  service:
+    type: ClusterIP
+    port: 8080
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+
 resources:
   requests:
     memory: "300Mi"

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -121,12 +121,13 @@ passthrough:
   snowflakeHost: ""
   service:
     type: ClusterIP
+  # Sized to match the main proxy — a real failover can send it full production traffic.
   resources:
     requests:
-      memory: "32Mi"
-      cpu: "25m"
+      memory: "300Mi"
+      cpu: "250m"
     limits:
-      memory: "64Mi"
+      memory: "600Mi"
 
 resources:
   requests:

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -94,7 +94,7 @@ ingress:
     servicePortName: ""
     servicePortNumber: ""
 
-# Bypass path: forwards straight to Snowflake when the proxy is unhealthy.
+# Bypass path: forwards straight to Snowflake/BigQuery when the proxy is unhealthy.
 passthrough:
   enabled: false
   replicaCount: 2
@@ -119,6 +119,8 @@ passthrough:
     healthPath: /health/live
   # Defaults to app.container.env.PROXY_HOST.
   snowflakeHost: ""
+  # Defaults to app.container.env.BIGQUERY_HOST. Takes precedence over Snowflake if both resolve.
+  bigqueryHost: ""
   service:
     type: ClusterIP
   # Sized to match the main proxy — a real failover can send it full production traffic.

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -108,6 +108,22 @@ passthrough:
   replicaCount: 2
   image: nginx:1.27-alpine
   port: 8080
+  # auto: watcher controls the proxy Service selector based on health.
+  # forcePassthrough / forceProxy: watcher pins the selector and skips health checks —
+  # for a deliberate, GitOps-reviewable override. Read live from a mounted ConfigMap,
+  # so changing this value takes effect within one poll interval, no pod restart needed.
+  mode: auto
+  # Watches app.container's own /health/live and flips the proxy Service's selector to
+  # the passthrough pods after enough consecutive failures (Kubernetes-native, so it
+  # works the same regardless of what's in front — ALB, nginx-ingress, anything —
+  # unlike ALB-specific weighted target groups, which only cover fully-hosted).
+  watcher:
+    enabled: true
+    image: curlimages/curl:8.11.0
+    pollIntervalSeconds: 5
+    failureThreshold: 3
+    successThreshold: 3
+    healthPath: /health/live
   # Snowflake account URL to forward to, e.g. "https://xyz.snowflakecomputing.com".
   # Defaults to the same host Yuki Proxy itself targets (app.container.env.PROXY_HOST)
   # so there's one source of truth; override only if they should ever differ.

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -107,7 +107,9 @@ passthrough:
   enabled: false
   replicaCount: 2
   image: nginx:1.27-alpine
-  port: 8080
+  # Always listens on app.service.port (not its own port) — required for the watcher's
+  # Service-selector swap: the proxy Service's targetPort is fixed, so whatever it
+  # selects (proxy or passthrough pods) must listen on that same port.
   # auto: watcher controls the proxy Service selector based on health.
   # forcePassthrough / forceProxy: watcher pins the selector and skips health checks —
   # for a deliberate, GitOps-reviewable override. Read live from a mounted ConfigMap,
@@ -130,7 +132,6 @@ passthrough:
   snowflakeHost: ""
   service:
     type: ClusterIP
-    port: 8080
   resources:
     requests:
       memory: "32Mi"

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -88,11 +88,20 @@ proxyDeploymentType: self_hosted
 
 ingress:
   enabled: false
+  # Overrides the Ingress rule's backend service/port. Empty by default (falls back to
+  # app.name / app.service.port, i.e. no behavior change). Set these to route through an
+  # ALB "actions." annotation (servicePortName: "use-annotation") for weighted bypass
+  # routing to the passthrough service below — that annotation itself is ALB-specific and
+  # lives in terraform-infra, not here, to keep this chart ingress-controller-agnostic.
+  backend:
+    serviceName: ""
+    servicePortName: ""
+    servicePortNumber: ""
 
 # Minimal, dependency-free fallback that forwards straight to Snowflake with
 # the correct Host header — a bypass path for when Yuki Proxy (or one of its
-# dependencies) is unhealthy. Off by default and not wired into `ingress` yet;
-# that wiring (weighted ALB target groups) is separate infra-repo work.
+# dependencies) is unhealthy. Off by default. Wire it into traffic via
+# ingress.backend above (weighted ALB target groups configured in terraform-infra).
 # See the "Yuki Proxy Bypass Options" design doc for the full rationale.
 passthrough:
   enabled: false

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -98,6 +98,13 @@ ingress:
 passthrough:
   enabled: false
   replicaCount: 2
+  # Real production traffic can land here during a failover — scale it accordingly.
+  hpa:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
   image: nginx:1.27-alpine
   # Must match app.service.port — the swapped Service's targetPort is fixed.
   # auto/forceProxy/forcePassthrough. Live-reloaded, no pod restart needed.


### PR DESCRIPTION
## Why
The March 4 incident (wrong Host header sent to Snowflake) had no fallback path — customer queries just failed. This gives ops a way to keep queries flowing during a proxy outage instead of a hard customer-facing failure.

## Summary
- Adds a minimal, dependency-free nginx Deployment/Service that forwards straight to Snowflake or BigQuery with the correct `Host` header — the foundational bypass path for when the proxy (or a dependency) is unhealthy. Both backends go through the same mechanism; whichever host is configured for the account is what the passthrough forwards to.
- Off by default (`passthrough.enabled: false`).
- **Ingress backend is overridable** (`ingress.backend.serviceName`/`servicePortName`/`servicePortNumber`), defaulting to today's behavior unchanged — lets `terraform-infra` route via an ALB "actions." backend if ever wanted, without ALB-specific logic in this chart.
- **Automatic + manual bypass switch, Kubernetes-native**: a sidecar (`watcher`, `curlimages/curl`) polls the real proxy's `/health/live` (via a stable, never-swapped `<name>-direct` Service — checking through the main Service would be circular once it's pointed at passthrough) and, after `passthrough.watcher.failureThreshold` consecutive failures, patches the proxy Service's `selector` to route to the passthrough pods instead — reverting after `successThreshold` consecutive successes. Since this works by repointing the Service (not the ALB), the same mechanism works identically for fully-hosted and self-hosted deployments regardless of what's in front. `passthrough.mode` (`auto`/`forceProxy`/`forcePassthrough`) gives a manual override, read live from a mounted ConfigMap so a values change takes effect within one poll interval, no pod restart. RBAC is scoped to `get`/`patch` on exactly the one named proxy Service.
- Passthrough always listens on `app.service.port` (not a separate port) — required so it can serve traffic correctly once the Service selector swaps onto it, since the Service's `targetPort` is fixed.
- Every watcher poll and mode transition is logged (`bypass-watcher: ...` prefix) for easy observability — the countdown to a switch is visible live in Groundcover, not just the switch itself.
- Bounded the passthrough pod's `cache`/`tmp` emptyDir volumes with `sizeLimit`.
- Reuses the existing chart's health-probe/preStop conventions at a smaller scale (`/healthz` instead of the app's `/health/*`, since nginx has no app logic to check).
- Upstream host defaults to whatever the main proxy already targets — Snowflake via `app.container.env.PROXY_HOST` (overridable via `passthrough.snowflakeHost`), BigQuery via `app.container.env.BIGQUERY_HOST` (overridable via `passthrough.bigqueryHost`, takes precedence if both resolve, matching ClientProxy's own route order). The `Host` header is always rewritten to the real upstream host — the client targets Yuki's hosted domain in both cases, not the real backend, so this is required for both Snowflake and BigQuery alike.
- **HPA for the passthrough** (`passthrough.hpa`, on by default, CPU/memory based, mirrors the main proxy's HPA) — a real failover can send full production traffic to the passthrough, so a static 2 replicas could be under-provisioned exactly when it matters.
- **Quieted `/healthz` access logs** (`access_log off` on that location) — k8s liveness/readiness probes hit it every few seconds per pod, which was flooding Groundcover with info-level noise.

Design doc: [Yuki Proxy Bypass Options](https://app.notion.com/p/319826a8884a80b9b3aed32c26e91c31)
Notion tasks: [passthrough workload](https://app.notion.com/p/394826a8884a8101b51df7284977164d), [bypass switch](https://app.notion.com/p/394826a8884a81be94f4dc057e25afbf)

## Pre-merge checklist
- [x] Disabled by default — zero behavior change unless `passthrough.enabled`/`ingress.backend` are explicitly set
- [x] No ALB-specific logic in the shared/generic templates — self-hosted customers on any ingress controller are unaffected
- [x] Watcher RBAC scoped to `get`/`patch` on exactly one named Service, nothing else

## Test strategy
Helm chart repo — no Playwright/SystemTests/ProxyTestClients apply here. Validated via `helm lint`/`helm template` plus live cluster deployment (see Test plan below).

## Test plan
- [x] `helm lint` passes with `passthrough.enabled` both `false` and `true`
- [x] `helm template` with defaults renders zero passthrough resources and an unchanged Ingress backend (confirmed no-op)
- [x] `helm template` with `ingress.backend.serviceName`/`servicePortName` overridden renders the expected weighted-routing backend shape
- [x] `helm template` with `passthrough.enabled=true` renders RBAC, both watcher-related Services, watcher ConfigMap, and the watcher sidecar on the passthrough Deployment
- [x] Deployed to a local kind cluster with `passthrough.enabled=true`, `passthrough.snowflakeHost=https://httpbin.org`; both replicas reached Ready
- [x] Hit the passthrough Service from inside the cluster and confirmed the upstream received a rewritten `Host: httpbin.org` header regardless of the inbound request — the exact mechanism behind the March 4 incident (wrong Host header → Snowflake 404), proven working in reverse
- [x] **End-to-end failover validated live against the real `dsexcvw-sb-ari` staging proxy (Snowflake)**: scaled the real proxy to 0 replicas → watcher logged the failure countdown and switched the Service to passthrough within one poll cycle → ran real Snowflake CLI queries confirming they kept succeeding through the passthrough → scaled the proxy back up → watcher logged the recovery countdown and reverted automatically → confirmed normal queries resumed
- [x] **End-to-end failover validated live against the real `yukitest-com` staging proxy (BigQuery)**: same cycle, using a real BigQuery client (`@google-cloud/bigquery`) executing a sync query through the passthrough. First run surfaced a real bug — the passthrough forwarded the client's original Host header unchanged, which works for the main proxy (YARP rewrites Host to the destination by default) but not for nginx (which doesn't), so Google's edge rejected it with a 404. Fixed by rewriting the Host header for BigQuery the same way as Snowflake, then re-verified the full failover cycle succeeds
- [x] Found and fixed three bugs only surfaced by live testing: a JSON-parsing regex that assumed compact JSON (API server pretty-prints), the circular health check described above (originally checked the same Service it swaps, so it could detect failure but never detect recovery), and the BigQuery Host-header gap above
- [x] **Manual `forceProxy`/`forcePassthrough` mode testing** — validated live: `forcePassthrough` switched immediately even with a healthy proxy (confirmed via real traffic returning `302`); `forceProxy` held the selector on the proxy through 40+s of a real outage with zero automatic failover (confirmed via a genuine `503`, proving the override truly skips health checks), then cleanly reverted to `auto`/`yuki-proxy` afterward
- [x] `helm template` confirms the passthrough Deployment has a static `replicas` field when `passthrough.hpa.enabled=false`, and none (HPA-owned) when enabled — same pattern as the main proxy; HPA object renders only under `passthrough.enabled && passthrough.hpa.enabled`
- [x] `helm template` confirms `access_log off;` renders inside the `/healthz` location block only — real traffic through `location /` is still logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
