### PR TITLE
YU-2023: make mcp.envShort case-insensitive

### DIFF
--- a/charts/yuki/templates/_helpers.tpl
+++ b/charts/yuki/templates/_helpers.tpl
@@ -37,7 +37,7 @@ INGESTION_KEY
 
 {{/* Short env token for secret paths: staging→stg, production→prod, development→dev. */}}
 {{- define "mcp.envShort" -}}
-{{- $env := required "app.container.env.ENVIRONMENT is required when mcp.enabled" .Values.app.container.env.ENVIRONMENT -}}
+{{- $env := required "app.container.env.ENVIRONMENT is required when mcp.enabled" .Values.app.container.env.ENVIRONMENT | lower -}}
 {{- if   eq $env "staging"     -}}stg
 {{- else if eq $env "production"  -}}prod
 {{- else if eq $env "development" -}}dev


### PR DESCRIPTION
## Summary
- Fixes an active ArgoCD failure: can't render because `mcp.envShort` did an exact-case match against `production`, but this repo's `ENVIRONMENT` values aren't consistently cased — staging sets `staging`, production sets `Production`.
- One-line fix: pipe through `lower` before comparing, matching the existing convention `deployment.yaml` already uses for `ASPNETCORE_ENVIRONMENT`.

## Error being fixed
```
execution error at (proxy/templates/externalsecret-mcp.yaml:19:16):
mcp.envShort: unknown ENVIRONMENT "Production" (expected staging|production|development)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment names are now handled consistently regardless of letter case, improving the accuracy of environment-specific behavior.
  * Error messages for unknown environments now reflect the normalized environment value, making issues easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->