### PR TITLE
feat(mcp): dedicated MCP subdomain ingress

### DIFF
--- a/charts/yuki/templates/ingress-mcp.yaml
+++ b/charts/yuki/templates/ingress-mcp.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.mcp.enabled .Values.mcp.ingress.enabled -}}
+{{- $host := required "mcp.host is required when mcp.ingress.enabled" .Values.mcp.host -}}
+# Dedicated MCP subdomain ingress (own ALB + cert), e.g. mcp.<namespace>.<domain>.
+# When this is enabled the /mcp,/oauth,/register,/.well-known path routes are dropped
+# from the proxy ingress (see ingress.yaml) — the MCP server owns the whole subdomain.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.mcp.ingress.name | default "yuki-mcp-ingress" }}
+  {{- with .Values.mcp.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ tpl (toString $value) $ | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.mcp.ingress.className | default .Values.ingress.className }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: yuki-mcp
+                port:
+                  number: 8000
+{{- end }}

--- a/charts/yuki/templates/ingress.yaml
+++ b/charts/yuki/templates/ingress.yaml
@@ -14,7 +14,7 @@ spec:
   rules:
     - http:
         paths:
-          {{- if .Values.mcp.enabled }}
+          {{- if and .Values.mcp.enabled (not .Values.mcp.ingress.enabled) }}
           # yuki-mcp mounts the MCP endpoint at /mcp, the OAuth flow at /oauth +
           # /register, and RFC 8414/9728 discovery at the origin root — route all
           # of them, or the unlisted ones fall through to the / proxy backend.

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -220,7 +220,11 @@ mcp:
   # MCP is path-routed (/mcp, /oauth, /register, /.well-known) on the proxy
   # ingress and baseUrl points at the proxy host. When enabled, MCP owns the
   # whole `host` subdomain — set baseUrl to https://<host> to match.
-  host: ""                 # e.g. mcp.<namespace>.yukistaging.com; required when ingress.enabled
+  # Full MCP host, set per-tenant; required when ingress.enabled. Convention is
+  # mcp-<namespace>.<domain> (single label — the *.<domain> wildcard cert covers
+  # it), e.g. mcp-jsjvnsg-prod-aws-n-virginia.yukicomputing.com. A dotted
+  # mcp.<namespace>.<domain> is 2 labels deep and needs its own dedicated cert.
+  host: ""
   ingress:
     enabled: false
     className: alb         # falls back to .Values.ingress.className if empty

--- a/charts/yuki/values.yaml
+++ b/charts/yuki/values.yaml
@@ -216,6 +216,15 @@ mcp:
   snowflakeAccount: ""     # Snowflake account id, e.g. jsjvnsg-staging
   integrationName: ""      # SystemManagement integration name for this account
   logLevel: "INFO"
+  # Dedicated MCP subdomain ingress (own ALB + cert). When disabled (default),
+  # MCP is path-routed (/mcp, /oauth, /register, /.well-known) on the proxy
+  # ingress and baseUrl points at the proxy host. When enabled, MCP owns the
+  # whole `host` subdomain — set baseUrl to https://<host> to match.
+  host: ""                 # e.g. mcp.<namespace>.yukistaging.com; required when ingress.enabled
+  ingress:
+    enabled: false
+    className: alb         # falls back to .Values.ingress.className if empty
+    annotations: {}        # ALB annotations (cert-arn, load-balancer-name, external-dns hostname, healthcheck…)
   hpa:
     enabled: false
     minReplicas: 1


### PR DESCRIPTION
## What

Adds an optional dedicated ingress so the MCP server can be served on its own subdomain (own ALB + cert), e.g. `mcp.<namespace>.<domain>`, instead of path-routing `/mcp` on the shared proxy host.

## Why

MCP OAuth/discovery works best from the origin root of a dedicated host. Staging already had this hand-applied (`yuki-mcp-ingress` → `yuki-mcp-sub`, created out-of-band); this makes it a first-class, reproducible chart feature for staging + prod.

## Changes

- **`templates/ingress-mcp.yaml`** *(new)* — dedicated ingress, gated on `mcp.enabled && mcp.ingress.enabled`; host from `mcp.host`, `/` → `yuki-mcp:8000`, annotations passed through (tpl-rendered) like the proxy ingress.
- **`templates/ingress.yaml`** — the `/mcp,/oauth,/register,/.well-known` path-routes now render only when the dedicated ingress is **off**, so the subdomain cleanly owns the whole host. Default (disabled) behavior is unchanged → non-breaking for existing tenants.
- **`values.yaml`** — new `mcp.host` + `mcp.ingress.{enabled,className,annotations}` (default off).

## Verification

- `helm template` in both modes: subdomain-on stands up `yuki-mcp-ingress` and drops the `/mcp*` routes from the proxy ingress; subdomain-off is byte-identical to before.
- `helm lint` passes.

## Rollout note

Consumed by terraform-infra (staging + prod jsjvnsg values). Staging tracks `proxyChartVersion: "*"` so it picks this up on release; prod pins a version and will be bumped after this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for serving MCP on a dedicated ingress using a separate host, with configurable ingress class and custom annotations.
  * You can choose between path-based routing through the main ingress or a separate host/subdomain for MCP.

* **Bug Fixes**
  * Updated ingress routing so MCP paths are only included in the main ingress when the dedicated MCP ingress is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->