### PR TITLE
YU-2156: co-locate yuki-mcp with yuki-proxy for Groundcover coverage

### DIFF
--- a/charts/yuki/templates/deployment-mcp.yaml
+++ b/charts/yuki/templates/deployment-mcp.yaml
@@ -29,6 +29,26 @@ spec:
     spec:
       serviceAccountName: {{ .Values.serviceAccount.serviceAccountName | default "default" }}
       terminationGracePeriodSeconds: 30
+      affinity:
+        {{- with .Values.affinity.nodeAffinity }}
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        # Co-locate with the proxy so the Groundcover sensor (required onto app: yuki-proxy) covers yuki-mcp too.
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: {{ .Values.app.name }}
+              topologyKey: kubernetes.io/hostname
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## Summary
- `yuki-mcp` logs weren't reaching Groundcover. Root cause: Groundcover's sensor DaemonSet requires co-location with an `app: yuki-proxy` pod (`values.yaml` `groundcover.agent.affinity.podAffinity`) — it never runs on a node without one.
- `deployment-mcp.yaml` had zero affinity/toleration/nodeSelector, so `yuki-mcp` pods could land anywhere. For `jsjvnsg-staging` specifically, the proxy is pinned to a tainted Karpenter nodepool that `yuki-mcp` couldn't even tolerate — guaranteeing zero sensor coverage, not just bad luck.
- Fix: mirror `deployment.yaml`'s existing `affinity`/`tolerations`/`nodeSelector` pass-through, plus a required `podAffinity` onto `app: {{ .Values.app.name }}` so `yuki-mcp` transitively always lands where the sensor already is.

## Why required (not preferred) affinity
`yuki-mcp` already has a hard runtime dependency on `yuki-proxy` (`SNOWFLAKE_HOST: yuki-proxy`) — if no proxy pod exists, MCP is already non-functional. A required podAffinity's worst case (`Pending` until schedulable) is strictly better than today's worst case (`Running` and silently erroring on every call), and matches the sensor's own existing `required` precedent — there's no `preferred` precedent anywhere in this chart.

## Verification
`helm template`/`helm lint` against `jsjvnsg-staging`'s real merged values (base + staging + region + account layers) — renders with the Karpenter toleration/nodeAffinity applied and the new podAffinity present, `helm lint` clean.

## Test plan
- [ ] Merge → release → bump `proxyChartVersion` → confirm on staging: `kubectl get pods -o wide` shows `yuki-mcp` on the same node as `yuki-proxy`, and `yuki-mcp` log lines appear in Groundcover for that tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable pod scheduling settings for the MCP deployment, including optional node affinity (with co-location rules), tolerations, and node selection.
  * When enabled, MCP pods can be scheduled alongside Pods matching the application label to improve workload placement control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->