### PR TITLE
fix(observability): authenticate groundcover OTLP with apikey header

### DIFF
--- a/charts/yuki/templates/observability/otel-collector.yaml
+++ b/charts/yuki/templates/observability/otel-collector.yaml
@@ -31,7 +31,9 @@ data:
       otlphttp/groundcover:
         endpoint: {{ $gc.endpoint }}
         headers:
-          Authorization: "Bearer ${env:GROUNDCOVER_API_KEY}"
+          # groundcover authenticates OTLP ingestion with an `apikey` header
+          # (NOT Authorization/Bearer — that is silently dropped server-side).
+          apikey: "${env:GROUNDCOVER_API_KEY}"
           {{- with $gc.envName }}
           x-groundcover-env-name: {{ . | quote }}
           {{- end }}


### PR DESCRIPTION
The OTLP backend's collector sent `Authorization: Bearer <key>` to groundcover. groundcover silently drops that (the OTLP endpoint returns 200/partialSuccess but never ingests) — it requires an `apikey: <key>` header instead. Switch the exporter header accordingly.

Verified end-to-end on staging (proxy -> otel-collector -> groundcover, 0 send failures across two clusters).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated telemetry export authentication to use the required API key header format.
  * Improved compatibility with Groundcover’s OTLP ingestion endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->