### PR TITLE
YU-2169 - Pass REDIS_URL and REDIS_CLUSTER to the mcp container

### DIFF
--- a/charts/yuki/templates/deployment-mcp.yaml
+++ b/charts/yuki/templates/deployment-mcp.yaml
@@ -98,10 +98,11 @@ spec:
               value: /tmp
             - name: AWS_REGION
               value: {{ .Values.app.container.env.AWS_REGION | default "eu-north-1" | quote }}
+            {{- $redisHost := required "app.container.env.REDIS_HOST is required when mcp.enabled" .Values.app.container.env.REDIS_HOST }}
             - name: REDIS_URL
-              value: "redis://{{ required "app.container.env.REDIS_HOST is required when mcp.enabled" .Values.app.container.env.REDIS_HOST }}:6379/0"
+              value: "redis://{{ $redisHost }}{{ if not (contains ":" $redisHost) }}:6379{{ end }}/0"
             - name: REDIS_CLUSTER
-              value: {{ contains "clustercfg" .Values.app.container.env.REDIS_HOST | quote }}
+              value: {{ contains "clustercfg" $redisHost | quote }}
             - name: YUKI_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/charts/yuki/templates/deployment-mcp.yaml
+++ b/charts/yuki/templates/deployment-mcp.yaml
@@ -98,6 +98,12 @@ spec:
               value: /tmp
             - name: AWS_REGION
               value: {{ .Values.app.container.env.AWS_REGION | default "eu-north-1" | quote }}
+            # Reuses the proxy's ElastiCache endpoint so there is one source of truth per
+            # environment; REDIS_CLUSTER is derived so a clustercfg endpoint can't be misflagged.
+            - name: REDIS_URL
+              value: "redis://{{ required "app.container.env.REDIS_HOST is required when mcp.enabled" .Values.app.container.env.REDIS_HOST }}:6379/0"
+            - name: REDIS_CLUSTER
+              value: {{ contains "clustercfg" .Values.app.container.env.REDIS_HOST | quote }}
             - name: YUKI_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/charts/yuki/templates/deployment-mcp.yaml
+++ b/charts/yuki/templates/deployment-mcp.yaml
@@ -98,8 +98,6 @@ spec:
               value: /tmp
             - name: AWS_REGION
               value: {{ .Values.app.container.env.AWS_REGION | default "eu-north-1" | quote }}
-            # Reuses the proxy's ElastiCache endpoint so there is one source of truth per
-            # environment; REDIS_CLUSTER is derived so a clustercfg endpoint can't be misflagged.
             - name: REDIS_URL
               value: "redis://{{ required "app.container.env.REDIS_HOST is required when mcp.enabled" .Values.app.container.env.REDIS_HOST }}:6379/0"
             - name: REDIS_CLUSTER


### PR DESCRIPTION
## Summary
yuki-mcp is adding a refresh-token grant (YU-2169) so the headless Cortex agents stop needing periodic human re-auth. That needs server-side state, so the mcp container needs a Redis endpoint — it currently has **no Redis env at all** (its list goes `AWS_REGION` → `YUKI_CLIENT_ID`).

Rather than add a new values key, this reuses `app.container.env.REDIS_HOST` — the same ElastiCache endpoint the proxy container already uses. So:
- nothing to set per-namespace; the value is already correct in every environment
- proxy and mcp cannot drift apart
- `REDIS_CLUSTER` is **derived** from whether the host contains `clustercfg`, so it can't be misflagged by hand

`required` is used deliberately: the new mcp image exits at startup if `REDIS_URL` is unset outside `development`, so a missing value should fail the Argo sync rather than deploy a crash-looping pod.

## Rendered output (verified locally with the real terraform-infra values)

| namespace | REDIS_URL | REDIS_CLUSTER |
|---|---|---|
| `jsjvnsg-prod-aws-n-virginia` | `redis://yuki-proxy-cache-cluster.fvofcj.clustercfg.use1.cache.amazonaws.com:6379/0` | `true` |
| `jsjvnsg-staging` | `redis://compute-stg.nhbmqe.ng.0001.eun1.cache.amazonaws.com:6379/0` | `false` |

Also verified: with `REDIS_HOST` absent the render **fails** (intended), and with `mcp.enabled=false` it renders fine — the guard is inside the `mcp.enabled` block, so namespaces without mcp are unaffected.

## Ordering — this must merge BEFORE yuki-mcp#9

The yuki-mcp CI writes its image tag to both staging and production values on merge, and the new image hard-fails without `REDIS_URL`. Shipping this chart change first is safe on its own: the currently-running mcp image simply ignores both new variables.

Note `Chart.yaml` is intentionally **not** bumped here — `release.yml` auto-increments it on main and pushes `proxyChartVersion` to terraform-infra itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis connectivity for MCP deployments by explicitly configuring the Redis connection URL and cluster detection.
  * Standardized Redis access to the configured host, port, and database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->